### PR TITLE
Pretend valid video config exists at startup

### DIFF
--- a/video.cpp
+++ b/video.cpp
@@ -858,17 +858,29 @@ void VidConfig(MPE &mpe)
     const VidDisplay *const pMainDisplay = (VidDisplay *)nuonEnv.GetPointerToMemory(mpe, display_addr);
     memcpy(&maindisplay,pMainDisplay,sizeof(VidDisplay));
     SwapScalarBytes((uint32 *)&maindisplay.bordcolor);
-
-    maindisplay.dispwidth = VIDEO_WIDTH;
-    maindisplay.dispheight = VIDEO_HEIGHT;
-    maindisplay.fps = 0;
-    maindisplay.progressive = -1;
   }
   else
   {
-    mpe.regs[0] = 1;
-    return; // leave unchanged from last call
+    if (!bCanDisplayVideo)
+    {
+      // bios.pdf says the BIOS always calls VidConfig before program startup,
+      // so there is always a valid video mode. If this is the first call,
+      // initialize some default video settings.
+      maindisplay.bordcolor = 0x10808000; // Black
+    }
+    else
+    {
+      // Reuse the last-set state.
+      memcpy(&maindisplay, &structMainDisplay, sizeof(VidDisplay));
+    }
   }
+
+  // Most of the video configuration is immutable in Nuance, as bios.pdf
+  // indicated was the case for "most" (all?) machines.
+  maindisplay.dispwidth = VIDEO_WIDTH;
+  maindisplay.dispheight = VIDEO_HEIGHT;
+  maindisplay.fps = 0;
+  maindisplay.progressive = -1;
 
   channelStatePrev = channelState;
   channelState = 0;


### PR DESCRIPTION
According to the documentation, the BIOS will
always initialize a valid video configuration
before the application is started, so applications can reasonably expect to be able to inherit that
mode by just querying it or making small
modifications to it and leaving other parameters
untouched. Some of the SDK sample programs, such
as the MGL samples, rely on this behavior.

To accomodate this, if no video mode has been
configured when _VidConfig() is called, initialize and enable video in Nuance's default state if the
application doesn't specify a main display config. Separate booleans still track whether the actual
main plane or overlay plane contain valid surfaces.