### PR TITLE
Add Joystick and configurable keybinding support

### DIFF
--- a/InputManager.cpp
+++ b/InputManager.cpp
@@ -1,0 +1,565 @@
+#include "InputManager.h"
+#include "joystick.h"
+#include "nuonenvironment.h"
+
+#include <stdio.h>
+
+#pragma warning(push)
+#pragma warning(disable:6000 28251)
+#include <dinput.h>
+#pragma warning(pop)
+
+extern NuonEnvironment nuonEnv;
+
+InputManager::~InputManager() {}
+
+class InputManagerImpl : public InputManager
+{
+private:
+  HINSTANCE hInstance;
+  HWND hWnd;
+  HWND hDisplayWnd;
+
+  static BOOL CALLBACK EnumJoystickObjectsCallback(const DIDEVICEOBJECTINSTANCE* pDi8DevObj, VOID* pContext);
+  static BOOL CALLBACK EnumJoysticksCallback(const DIDEVICEINSTANCE* pDi8Dev, VOID* pContext);
+
+  LPDIRECTINPUT8 pDi8;
+  LPDIRECTINPUTDEVICE8* pDi8Devs;
+
+  Joystick* pJoysticks;
+  size_t joyArrayLen;
+
+  size_t numJoysticks;
+  LPDIRECTINPUTDEVICE8 pJoystick1;
+  LPDIRECTINPUTDEVICE8 pGrabbedJoy;
+
+  unsigned int whichController;
+  uint16 keyButtons;
+  uint16 joyButtons;
+
+public:
+  InputManagerImpl() : InputManager(),
+    hInstance(nullptr),
+    hWnd(nullptr),
+    hDisplayWnd(nullptr),
+    pDi8(nullptr),
+    pDi8Devs(nullptr),
+    pJoysticks(nullptr),
+    joyArrayLen(0),
+    numJoysticks(0),
+    pJoystick1(nullptr),
+    pGrabbedJoy(nullptr),
+    whichController(1),
+    keyButtons(0),
+    joyButtons(0)
+  {
+  };
+  ~InputManagerImpl();
+
+  bool Init(HWND hDisplayWnd);
+  void Activate();
+  bool SetJoystick(size_t i);
+  void UpdateState(CONTROLLER_CALLBACK applyState, ANYPRESSED_CALLBACK anyPressed, void* anyCtx);
+  virtual void keyDown(CONTROLLER_CALLBACK applyState, int16 vkey);
+  virtual void keyUp(CONTROLLER_CALLBACK applyState, int16 vkey);
+  bool GrabJoystick(HWND hWnd, size_t i);
+  void UngrabJoystick();
+  const Joystick* EnumJoysticks(size_t* pNumJoysticks);
+};
+
+struct ManagerAndDev
+{
+  InputManagerImpl* im;
+  LPDIRECTINPUTDEVICE8 pDi8Dev;
+};
+
+BOOL CALLBACK InputManagerImpl::EnumJoystickObjectsCallback(const DIDEVICEOBJECTINSTANCE* pDi8DevObj, VOID* pContext)
+{
+  ManagerAndDev* md = (ManagerAndDev*)pContext;
+  TCHAR objMsg[1024];
+  (void)objMsg;
+
+  if (pDi8DevObj->dwType & DIDFT_PSHBUTTON)
+  {
+    /*_tcscpy_s(objMsg, _countof(objMsg), _T("Found a joystick button: "));
+    _tcscat_s(objMsg, _countof(objMsg), pDi8DevObj->tszName);
+    MessageBox(nullptr, objMsg, "Button found", MB_ICONINFORMATION);*/
+  }
+  else if (pDi8DevObj->dwType & DIDFT_ABSAXIS)
+  {
+    /*_tcscpy_s(objMsg, _countof(objMsg), _T("Found a joystick axis: "));
+    _tcscat_s(objMsg, _countof(objMsg), pDi8DevObj->tszName);
+    MessageBox(nullptr, objMsg, "Button found", MB_ICONINFORMATION);*/
+
+    // XXX Hack: Force axis to trinary values (-1, 0, 1)
+    DIPROPRANGE propRange = { 0 };
+    propRange.diph.dwSize = sizeof(propRange);
+    propRange.diph.dwHeaderSize = sizeof(propRange.diph);
+    propRange.diph.dwHow = DIPH_BYID;
+    propRange.diph.dwObj = pDi8DevObj->dwType;
+    propRange.lMin = -1;
+    propRange.lMax = 1;
+
+    HRESULT hr = md->pDi8Dev->SetProperty(DIPROP_RANGE, &propRange.diph);
+
+    if (FAILED(hr))
+    {
+      MessageBox(nullptr, "Failed DIRECTINPUTDEVICE8::SetProperty()", "Error", MB_ICONWARNING);
+      return DIENUM_STOP;
+    }
+  }
+
+  return DIENUM_CONTINUE;
+}
+
+BOOL CALLBACK InputManagerImpl::EnumJoysticksCallback(const DIDEVICEINSTANCE* pDi8Dev, VOID* pContext)
+{
+  InputManagerImpl* im = (InputManagerImpl*)pContext;
+  size_t i = im->numJoysticks;
+
+  if (im->joyArrayLen < (i + 1))
+  {
+    size_t newJoyArrayLen = im->joyArrayLen ? im->joyArrayLen * 2 : 1;
+    Joystick* newJoyArray = (Joystick*)realloc(im->pJoysticks, sizeof(im->pJoysticks[0]) * newJoyArrayLen);
+    LPDIRECTINPUTDEVICE8* newDi8Devs = (LPDIRECTINPUTDEVICE8*)realloc(im->pDi8Devs, sizeof(im->pDi8Devs[0]) * newJoyArrayLen);
+
+    if (!newJoyArray || !newDi8Devs) {
+      im->numJoysticks--;
+      return DIENUM_STOP;
+    }
+
+    im->pJoysticks = newJoyArray;
+    im->pDi8Devs = newDi8Devs;
+    im->joyArrayLen = newJoyArrayLen;
+  }
+
+  /*TCHAR joyMsg[1024];
+
+  _sntprintf_s(joyMsg, _countof(joyMsg), _T("Found a joystick: %s - %s"), pDi8Dev->tszProductName, pDi8Dev->tszInstanceName);
+  MessageBox(nullptr, joyMsg, "Joystick found", MB_ICONINFORMATION); */
+
+  HRESULT hr = im->pDi8->CreateDevice(pDi8Dev->guidInstance, &im->pDi8Devs[i], nullptr);
+
+  if (FAILED(hr))
+  {
+    MessageBox(nullptr, "Failed DirectInput::CreateDevice()", "Error", MB_ICONWARNING);
+    return DIENUM_CONTINUE;
+  }
+
+  hr = im->pDi8Devs[i]->SetDataFormat(&c_dfDIJoystick2);
+
+  if (FAILED(hr))
+  {
+    MessageBox(nullptr, "Failed DIRECTINPUTDEVICE8::SetDataFormat()", "Error", MB_ICONWARNING);
+    im->pDi8Devs[i]->Release();
+    im->pDi8Devs[i] = nullptr;
+    return DIENUM_CONTINUE;
+  }
+
+  hr = im->pDi8Devs[i]->SetCooperativeLevel(im->hWnd, DISCL_EXCLUSIVE | DISCL_BACKGROUND);
+
+  if (FAILED(hr))
+  {
+    MessageBox(nullptr, "Failed DIRECTINPUTDEVICE8::SetCooperativeLevel()", "Error", MB_ICONWARNING);
+    im->pDi8Devs[i]->Release();
+    im->pDi8Devs[i] = nullptr;
+    return DIENUM_CONTINUE;
+  }
+
+  ManagerAndDev md;
+  md.im = im;
+  md.pDi8Dev = im->pDi8Devs[i];
+  hr = im->pDi8Devs[i]->EnumObjects(EnumJoystickObjectsCallback, &md, DIDFT_ABSAXIS | DIDFT_PSHBUTTON | DIDFT_POV);
+
+  if (FAILED(hr))
+  {
+    MessageBox(nullptr, "Failed DIRECTINPUTDEVICE8::EnumObjects()", "Error", MB_ICONWARNING);
+    im->pDi8Devs[i]->Release();
+    im->pDi8Devs[i] = nullptr;
+    return DIENUM_CONTINUE;
+  }
+
+  im->pJoysticks[i].guid = pDi8Dev->guidInstance;
+  _tcscpy_s(im->pJoysticks[i].tszName, _countof(im->pJoysticks[i].tszName), pDi8Dev->tszInstanceName);
+  im->numJoysticks++;
+
+  if (im->pJoysticks[i].guid == nuonEnv.GetController1Joystick())
+  {
+    im->pJoystick1 = im->pDi8Devs[i];
+  }
+
+  return DIENUM_CONTINUE;
+}
+
+bool InputManagerImpl::Init(HWND hDpyWnd)
+{
+  hDisplayWnd = hWnd = hDpyWnd;
+  hInstance = (HINSTANCE)GetWindowLong(hWnd, GWL_HINSTANCE);
+
+  HRESULT hr = DirectInput8Create(hInstance, DIRECTINPUT_VERSION,
+    IID_IDirectInput8, (VOID**)&pDi8, nullptr);
+
+  if (FAILED(hr))
+  {
+    MessageBox(nullptr, "Failed DirectInput8Create()", "Error", MB_ICONWARNING);
+    return false;
+  }
+
+  hr = pDi8->EnumDevices(DI8DEVCLASS_GAMECTRL, EnumJoysticksCallback, this, DIEDFL_ATTACHEDONLY);
+
+  if (FAILED(hr) || (numJoysticks == 0))
+  {
+    MessageBox(nullptr, "Failed to enumerate joysticks, or no joystick found", "Error", MB_ICONWARNING);
+    return false;
+  }
+
+  if (!pJoystick1) pJoystick1 = pDi8Devs[0];
+
+  return true;
+}
+
+InputManagerImpl::~InputManagerImpl()
+{
+  if (pJoystick1)
+  {
+    pJoystick1->Unacquire();
+    pJoystick1 = nullptr;
+  }
+
+  for (size_t i = 0; i < numJoysticks; i++)
+  {
+    pDi8Devs[i]->Release();
+  }
+
+  free(pDi8Devs);
+  free(pJoysticks);
+
+  if (pDi8)
+  {
+    pDi8->Release();
+    pDi8 = nullptr;
+  }
+}
+
+void InputManagerImpl::Activate()
+{
+  if (pJoystick1) pJoystick1->Acquire();
+}
+
+bool InputManagerImpl::SetJoystick(size_t idx)
+{
+  if (idx >= numJoysticks) return false;
+  if (pGrabbedJoy) return false;
+  if (pJoystick1) pJoystick1->Unacquire();
+
+  pJoystick1 = pDi8Devs[idx];
+
+  pJoystick1->Acquire();
+
+  return true;
+}
+
+bool InputManagerImpl::GrabJoystick(HWND hWndGrab, size_t i)
+{
+  // Can't grab twice without ungrabbing
+  if (hWnd != hDisplayWnd) return false;
+
+  if (i >= numJoysticks) return false;
+
+  if (pDi8Devs[i] == pJoystick1) pJoystick1->Unacquire();
+
+  HRESULT hr = pDi8Devs[i]->SetCooperativeLevel(hWndGrab, DISCL_EXCLUSIVE | DISCL_BACKGROUND);
+
+  if (FAILED(hr))
+  {
+    MessageBox(nullptr, "Failed DIRECTINPUTDEVICE8::SetCooperativeLevel()", "Error", MB_ICONWARNING);
+    return false;
+  }
+
+  hr = pDi8Devs[i]->Acquire();
+
+  if (FAILED(hr))
+  {
+    pDi8Devs[i]->SetCooperativeLevel(hWnd, DISCL_EXCLUSIVE | DISCL_BACKGROUND);
+    MessageBox(nullptr, "Failed DIRECTINPUTDEVICE8::Acquire()", "Error", MB_ICONWARNING);
+    return false;
+  }
+
+  hWnd = hWndGrab;
+  pGrabbedJoy = pDi8Devs[i];
+
+  return true;
+}
+
+void InputManagerImpl::UngrabJoystick()
+{
+  if (hWnd == hDisplayWnd) return;
+
+  hWnd = hDisplayWnd;
+
+  pGrabbedJoy->Unacquire();
+
+  pGrabbedJoy->SetCooperativeLevel(hWnd, DISCL_EXCLUSIVE | DISCL_BACKGROUND);
+
+  if (pGrabbedJoy == pJoystick1)
+  {
+    pJoystick1->Acquire();
+  }
+
+  pGrabbedJoy = nullptr;
+}
+
+const Joystick* InputManagerImpl::EnumJoysticks(size_t* pNumJoysticks)
+{
+  *pNumJoysticks = numJoysticks;
+  return pJoysticks;
+}
+
+void InputManagerImpl::UpdateState(CONTROLLER_CALLBACK applyState, ANYPRESSED_CALLBACK anyPressed, void* anyCtx)
+{
+  DIJOYSTATE2 js;
+  HRESULT hr;
+  LPDIRECTINPUTDEVICE8 pJoy = pGrabbedJoy ? pGrabbedJoy : pJoystick1;
+
+  do {
+    hr = pJoy->Poll();
+    if (!FAILED(hr)) hr = pJoy->GetDeviceState(sizeof(DIJOYSTATE2), &js);
+    if (FAILED(hr)) hr = pJoy->Acquire();
+  } while (hr == DIERR_INPUTLOST);
+
+  if (!FAILED(hr))
+  {
+    InputType type;
+    int idx;
+    int subIdx;
+
+#define DO_CTRLR1()                                                                             \
+  do {                                                                                          \
+    CURSTATE() = true;                                                                          \
+    int bitnum = nuonEnv.GetCTRLRBitnumFromMapping(ControllerButtonMapping(type, idx, subIdx)); \
+    if (bitnum >= 0) joyButtons |= (1 << bitnum);                                               \
+  } while (0)
+
+#define DO_ANYPRESSED()                                   \
+    do {                                                  \
+        if (anyPressed && (CURSTATE() && !PREVSTATE())) { \
+            anyPressed(anyCtx, type, idx, subIdx);        \
+            return;                                       \
+        }                                                 \
+    } while (0)
+
+    joyButtons = 0;
+
+    static bool povLastState[_countof(js.rgdwPOV)][4] = {};
+    bool povState[_countof(js.rgdwPOV)][4] = {};
+#define CURSTATE() (povState[idx][subIdx])
+#define PREVSTATE() (povLastState[idx][subIdx])
+    type = JOYPOV;
+    for (idx = 0; idx < _countof(js.rgdwPOV); idx++)
+    {
+      DWORD angle = js.rgdwPOV[idx];
+
+      if (LOWORD(angle) == 0xFFFF) continue; // Centered
+
+      if ((angle > 33750) || (angle <= 2250))
+      {
+        // North
+        subIdx = 0;
+        povState[idx][subIdx] = true;
+        DO_CTRLR1();
+        DO_ANYPRESSED();
+      }
+      else if ((angle > 2250) && (angle <= 6750))
+      {
+        // Northeast
+        subIdx = 0;
+        DO_CTRLR1();
+        subIdx = 1;
+        DO_CTRLR1();
+        // DO_ANYPRESSED(); Unclear which button this is.
+      }
+      else if ((angle > 6750) && (angle <= 11250))
+      {
+        // East
+        subIdx = 1;
+        DO_CTRLR1();
+        DO_ANYPRESSED();
+      }
+      else if ((angle > 11250) && (angle <= 15750))
+      {
+        // Southeast
+        subIdx = 1;
+        DO_CTRLR1();
+        subIdx = 2;
+        DO_CTRLR1();
+        // DO_ANYPRESSED(); Unclear which button this is.
+      }
+      else if ((angle > 15750) && (angle <= 20250))
+      {
+        // Down
+        subIdx = 2;
+        DO_CTRLR1();
+        DO_ANYPRESSED();
+      }
+      else if ((angle > 20250) && (angle <= 24750))
+      {
+        // Southwest
+        subIdx = 2;
+        DO_CTRLR1();
+        subIdx = 3;
+        DO_CTRLR1();
+        // DO_ANYPRESSED(); Unclear which button this is.
+      }
+      else if ((angle > 24750) && (angle <= 29250))
+      {
+        // West
+        subIdx = 3;
+        DO_CTRLR1();
+        DO_ANYPRESSED();
+      }
+      else if ((angle > 29250) && (angle <= 33750))
+      {
+        // Northwest
+        subIdx = 3;
+        DO_CTRLR1();
+        subIdx = 0;
+        DO_CTRLR1();
+        // DO_ANYPRESSED(); Unclear which button this is.
+      }
+    }
+    memcpy_s(&povLastState[0][0], sizeof(povLastState), &povState[0][0], sizeof(povState));
+#undef CURSTATE
+#undef PREVSTATE
+
+    static bool axisLastState[&js.rglSlider[_countof(js.rglSlider)] - &js.lX][2] = {};
+    bool axisState[&js.rglSlider[_countof(js.rglSlider)] - &js.lX][2] = {};
+#define CURSTATE() (axisState[idx][subIdx])
+#define PREVSTATE() (axisLastState[idx][subIdx])
+    type = JOYAXIS;
+    LONG* pAxis;
+    for (idx = 0, pAxis = &js.lX; &pAxis[idx] < &js.rglSlider[_countof(js.rglSlider)]; idx++)
+    {
+      // type = JOYAXIS, index = i, subIndex = MIN->0, MAX->1
+      switch (pAxis[idx]) {
+      case -1:
+        subIdx = 0;
+        DO_CTRLR1();
+        DO_ANYPRESSED();
+        break;
+      case 1:
+        subIdx = 1;
+        DO_CTRLR1();
+        DO_ANYPRESSED();
+        break;
+      default:
+        break;
+      }
+    }
+    memcpy_s(&axisLastState[0][0], sizeof(axisLastState), &axisState[0][0], sizeof(axisState));
+#undef CURSTATE
+#undef PREVSTATE
+
+    static bool butLastState[_countof(js.rgbButtons)] = {};
+    bool butState[_countof(js.rgbButtons)] = {};
+#define CURSTATE() (butState[idx])
+#define PREVSTATE() (butLastState[idx])
+    type = JOYBUT;
+    subIdx = 0;
+    for (idx = 0; idx < _countof(js.rgbButtons); idx++)
+    {
+      if (js.rgbButtons[idx] & 0x80)
+      {
+        /*
+        TCHAR buttonMsg[1024];
+        _sntprintf_s(buttonMsg, _countof(buttonMsg), _T("Button %d pressed"), i);
+        MessageBox(nullptr, buttonMsg, "Button pressed", MB_ICONINFORMATION);
+        */
+        DO_CTRLR1();
+        DO_ANYPRESSED();
+      }
+    }
+    memcpy_s(&butLastState[0], sizeof(butLastState), &butState[0], sizeof(butState));
+#undef CURSTATE
+#undef PREVSTATE
+
+    if (applyState) applyState(whichController, keyButtons | joyButtons);
+  }
+}
+
+void InputManagerImpl::keyDown(CONTROLLER_CALLBACK applyState, int16 vkey)
+{
+  int bitNum = nuonEnv.GetCTRLRBitnumFromMapping(ControllerButtonMapping(KEY, vkey, 0));
+
+  if (bitNum >= 0)
+  {
+    keyButtons |= 1 << bitNum;
+  }
+
+  if (applyState) applyState(whichController, keyButtons | joyButtons);
+}
+
+void InputManagerImpl::keyUp(CONTROLLER_CALLBACK applyState, int16 vkey)
+{
+  int bitNum = nuonEnv.GetCTRLRBitnumFromMapping(ControllerButtonMapping(KEY, vkey, 0));
+
+  if (bitNum >= 0)
+  {
+    keyButtons &= ~(1 << bitNum);
+  }
+
+  if (vkey == 'Z')
+  {
+    whichController = 1 - whichController;
+  }
+
+  if (applyState) applyState(whichController, keyButtons | joyButtons);
+}
+
+
+InputManager* InputManager::Create()
+{
+  return new InputManagerImpl();
+}
+
+bool InputManager::StrToInputType(const char* str, InputType* type)
+{
+#define TYPE_CASE(t) \
+do { \
+  if (!_stricmp(#t, str)) \
+  { \
+    *type = t; \
+    return true; \
+  } \
+} while (0)
+
+  TYPE_CASE(KEY);
+  TYPE_CASE(JOYPOV);
+  TYPE_CASE(JOYAXIS);
+  TYPE_CASE(JOYBUT);
+
+#undef TYPE_CASE
+
+  return false;
+}
+
+const char* InputManager::InputTypeToStr(InputType type)
+{
+#define TYPE_CASE(t) \
+do { \
+  case t: return #t; \
+} while (0)
+
+  switch (type)
+  {
+    TYPE_CASE(KEY);
+    TYPE_CASE(JOYPOV);
+    TYPE_CASE(JOYAXIS);
+    TYPE_CASE(JOYBUT);
+  default:
+    // Only reached if someone adds a new type and forgets to update this function
+    return "<Update_InputTypeToStr>";
+  }
+
+#undef TYPE_CASE
+}
+

--- a/InputManager.h
+++ b/InputManager.h
@@ -1,0 +1,49 @@
+#ifndef InputManagerH
+#define InputManagerH
+
+#include "basetypes.h"
+#include <windows.h>
+#include <tchar.h>
+
+struct Joystick
+{
+  GUID guid;
+  TCHAR tszName[MAX_PATH];
+};
+
+class InputManager
+{
+protected:
+  InputManager() {}
+public:
+  enum InputType {
+    // When modifying, update StrToInputType().
+    KEY,
+    JOYPOV,
+    JOYAXIS,
+    JOYBUT,
+  };
+
+  static InputManager* Create();
+  static bool StrToInputType(const char* str, InputType* type);
+  static const char* InputManager::InputTypeToStr(InputType type);
+
+
+  typedef void (*CONTROLLER_CALLBACK)(unsigned int controllerIdx, unsigned __int16 buttons);
+  typedef void (*ANYPRESSED_CALLBACK)(void* ctx, InputType type, int idx, int subIdx);
+
+  virtual ~InputManager() = 0;
+
+  virtual bool Init(HWND hDisplayWnd) = 0;
+  virtual void Activate() = 0;
+  virtual bool SetJoystick(size_t idx) = 0;
+  virtual void UpdateState(CONTROLLER_CALLBACK applyState, ANYPRESSED_CALLBACK anyPressed, void* anyCtx) = 0;
+  virtual void keyDown(CONTROLLER_CALLBACK applyState, int16 vkey) = 0;
+  virtual void keyUp(CONTROLLER_CALLBACK applyState, int16 vkey) = 0;
+  virtual bool GrabJoystick(HWND hWnd, size_t i) = 0;
+  virtual void UngrabJoystick() = 0;
+  virtual const Joystick* EnumJoysticks(size_t* pNumJoysticks) = 0;
+};
+
+#endif
+

--- a/Nuance.rc
+++ b/Nuance.rc
@@ -7,19 +7,17 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "windows.h"
+#include "afxres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (U.S.) resources
+// English (United States) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
-#endif //_WIN32
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -56,12 +54,13 @@ END
 // remains consistent on all systems.
 IDI_APPICON             ICON                    "Nuance.ico"
 
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Dialog
 //
 
-IDD_CONTROL_PANEL DIALOGEX 100, 100, 468, 270
+IDD_CONTROL_PANEL DIALOGEX 100, 100, 468, 290
 STYLE DS_SETFONT | DS_NOIDLEMSG | DS_3DLOOK | DS_FIXEDSYS | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_NOPARENTNOTIFY | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE | WS_EX_APPWINDOW
 CAPTION "Nuance Control Panel"
@@ -79,13 +78,14 @@ BEGIN
     LTEXT           "$80010000",IDC_MPE1_PCEXEC,56,31,37,8
     LTEXT           "$80010000",IDC_MPE3_PCEXEC,56,62,37,8
     LTEXT           "$80010000",IDC_MPE2_PCEXEC,56,47,37,8
-    CONTROL         "",RE_TERM_DISPLAY,"RichEdit20A",ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_NOHIDESEL | ES_READONLY | WS_BORDER | WS_VSCROLL | WS_HSCROLL,122,11,317,219
-    EDITTEXT        EB_TERM_INPUT,124,239,315,14,ES_AUTOHSCROLL
-    PUSHBUTTON      "Reset",IDC_CB_RESET,18,225,67,29
-    PUSHBUTTON      "Run",IDC_CB_RUN,18,160,67,29
-    PUSHBUTTON      "Stop",IDC_CB_STOP,18,193,67,29
-    PUSHBUTTON      "Load File",IDC_CB_LOAD_FILE,18,94,67,29
-    PUSHBUTTON      "Single Step",IDC_CB_SINGLE_STEP,18,126,67,29
+    CONTROL         "",RE_TERM_DISPLAY,"RichEdit20A",ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_NOHIDESEL | ES_READONLY | WS_BORDER | WS_VSCROLL | WS_HSCROLL,122,11,317,238
+    EDITTEXT        EB_TERM_INPUT,123,259,315,14,ES_AUTOHSCROLL
+    PUSHBUTTON      "Reset",IDC_CB_RESET,18,212,67,29
+    PUSHBUTTON      "Run",IDC_CB_RUN,18,148,67,29
+    PUSHBUTTON      "Stop",IDC_CB_STOP,18,180,67,29
+    PUSHBUTTON      "Load File",IDC_CB_LOAD_FILE,18,84,67,29
+    PUSHBUTTON      "Single Step",IDC_CB_SINGLE_STEP,18,116,67,29
+    PUSHBUTTON      "Configure Input",IDC_CB_CFG_INPUT,18,244,67,29
 END
 
 IDD_SPLASH_SCREEN DIALOGEX 0, 0, 353, 137
@@ -109,6 +109,50 @@ BEGIN
     PUSHBUTTON      "Dump MPEs",IDC_DUMP_MPES,296,275,70,35
 END
 
+IDD_CFG_INPUT DIALOGEX 0, 0, 399, 176
+STYLE DS_SETFONT | DS_MODALFRAME | DS_3DLOOK | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Configure Input"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    GROUPBOX        "Player 1",IDC_STATIC,7,7,383,144
+    EDITTEXT        IDC_SET_DUP,54,36,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "DPad Up",IDC_LABEL_DUP,12,36,28,8
+    EDITTEXT        IDC_SET_DDOWN,54,54,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "DPad Down",IDC_LABEL_DDOWN,12,54,38,8
+    EDITTEXT        IDC_SET_DLEFT,54,72,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "DPad Left",IDC_LABEL_DLEFT,12,72,32,8
+    EDITTEXT        IDC_SET_DRIGHT,54,90,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "DPad Right",IDC_LABEL_DRIGHT,12,90,36,8
+    EDITTEXT        IDC_SET_NUON,54,108,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "Nuon",IDC_LABEL_NUON,12,108,18,8
+    EDITTEXT        IDC_SET_START,54,126,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "Start",IDC_LABEL_START,12,126,17,8
+    EDITTEXT        IDC_SET_CUP,180,36,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "CPad Up",IDC_LABEL_CUP,138,36,28,8
+    EDITTEXT        IDC_SET_CDOWN,180,54,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "CPad Down",IDC_LABEL_CDOWN,138,54,38,8
+    EDITTEXT        IDC_SET_CLEFT,180,72,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "CPad Left",IDC_LABEL_CLEFT,138,72,32,8
+    EDITTEXT        IDC_SET_CRIGHT,180,90,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "CPad Right",IDC_LABEL_CRIGHT,138,90,36,8
+    EDITTEXT        IDC_SET_A,180,108,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "A",IDC_LABEL_A,138,108,8,8
+    EDITTEXT        IDC_SET_B,180,126,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "B",IDC_LABEL_B,138,126,8,8
+    EDITTEXT        IDC_SET_L,306,36,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "L",IDC_LABEL_L,264,36,8,8
+    EDITTEXT        IDC_SET_R,306,54,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY
+    LTEXT           "R",IDC_LABEL_R,264,54,8,8
+    EDITTEXT        IDD_SET_ANALOGX,306,72,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY | WS_DISABLED
+    LTEXT           "Analog X",IDC_LABEL_ANALOGX,264,72,36,8
+    EDITTEXT        IDD_SET_ANALOGY,306,90,72,14,ES_CENTER | ES_UPPERCASE | ES_READONLY | WS_DISABLED
+    LTEXT           "Analog Y",IDC_LABEL_ANALOGY,264,90,36,8
+    COMBOBOX        IDC_JOYSTICK_COMBO,96,18,180,126,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Joystick",IDC_STATIC,54,18,36,8
+    DEFPUSHBUTTON   "OK",IDB_OK,282,156,48,12
+    PUSHBUTTON      "Cancel",IDB_CANCEL,336,156,48,12
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -122,7 +166,7 @@ BEGIN
     BEGIN
         RIGHTMARGIN, 463
         TOPMARGIN, 2
-        BOTTOMMARGIN, 263
+        BOTTOMMARGIN, 283
     END
 
     IDD_STATUS_DIALOG, DIALOG
@@ -131,6 +175,14 @@ BEGIN
         RIGHTMARGIN, 388
         TOPMARGIN, 7
         BOTTOMMARGIN, 309
+    END
+
+    IDD_CFG_INPUT, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 392
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 169
     END
 END
 #endif    // APSTUDIO_INVOKED
@@ -142,9 +194,12 @@ END
 //
 
 IDB_NUANCE_LOGO         BITMAP                  "NuanceLogo.bmp"
+
 IDB_LED_ON              BITMAP                  "led_on.bmp"
+
 IDB_LED_OFF             BITMAP                  "led_off.bmp"
-#endif    // English (U.S.) resources
+
+#endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 
 
@@ -158,3 +213,4 @@ IDB_LED_OFF             BITMAP                  "led_off.bmp"
 
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
+

--- a/Nuance.vcxproj
+++ b/Nuance.vcxproj
@@ -72,7 +72,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>external\glew-2.2.0\lib\Release\Win32\glew32.lib;user32.lib;winmm.lib;external\fmod-3.75\api\lib\fmodvc.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>external\glew-2.2.0\lib\Release\Win32\glew32.lib;user32.lib;winmm.lib;external\fmod-3.75\api\lib\fmodvc.lib;opengl32.lib;dxguid.lib;dinput8.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)Nuance.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)Nuance.pdb</ProgramDatabaseFile>
@@ -110,7 +110,7 @@
       <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>external\glew-2.2.0\lib\Release\Win32\glew32.lib;user32.lib;winmm.lib;external\fmod-3.75\api\lib\fmodvc.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>external\glew-2.2.0\lib\Release\Win32\glew32.lib;user32.lib;winmm.lib;external\fmod-3.75\api\lib\fmodvc.lib;opengl32.lib;dxguid.lib;dinput8.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)Nuance.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>false</GenerateMapFile>
@@ -216,6 +216,7 @@
     </ClCompile>
     <ClCompile Include="FlashEEPROM.cpp" />
     <ClCompile Include="GLWindow.cpp" />
+    <ClCompile Include="InputManager.cpp" />
     <ClCompile Include="InstructionCache.cpp">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Full</Optimization>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">StreamingSIMDExtensions</EnableEnhancedInstructionSet>
@@ -362,6 +363,7 @@
     <ClInclude Include="FlashEEPROM.h" />
     <ClInclude Include="GLWindow.h" />
     <ClInclude Include="Handlers.h" />
+    <ClInclude Include="InputManager.h" />
     <ClInclude Include="InstructionCache.h" />
     <ClInclude Include="InstructionDependencies.h" />
     <ClInclude Include="joystick.h" />

--- a/Nuance.vcxproj.filters
+++ b/Nuance.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClCompile Include="CriticalSection.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="InputManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="audio.h">
@@ -456,6 +459,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="external\xxhash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="InputManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/NuanceRes.h
+++ b/NuanceRes.h
@@ -10,10 +10,13 @@
 #define IDI_APPICON                     113
 #define IDD_CONTROL_PANEL               114
 #define IDD_SPLASH_SCREEN               115
+#define IDD_SET_ANALOGX                 115
 #define IDB_NUANCE_LOGO                 116
+#define IDD_SET_ANALOGY                 116
 #define IDB_LED_ON                      117
 #define IDB_LED_OFF                     126
 #define IDD_STATUS_DIALOG               127
+#define IDD_CFG_INPUT                   129
 #define RE_TERM_DISPLAY                 1002
 #define IDC_MPE0_LED                    1003
 #define IDC_MPE1_LED                    1004
@@ -29,21 +32,57 @@
 #define IDC_LABEL_MPE1                  1014
 #define IDC_LABEL_MPE2                  1015
 #define IDC_LABEL_MPE3                  1016
+#define IDC_CB_CFG_INPUT                1017
 #define IDC_COMM_STATUS                 1018
 #define IDC_DISPLAY_STATUS              1019
 #define IDC_MPE_STATUS                  1020
 #define RE_STATUS_DISPLAY               1021
 #define IDC_DUMP_MPE                    1022
 #define IDC_DUMP_MPES                   1022
+#define IDB_OK                          1022
+#define IDB_CANCEL                      1023
+#define IDC_SET_DUP                     1033
+#define IDC_LABEL_DUP                   1034
+#define IDC_SET_DDOWN                   1035
+#define IDC_LABEL_DDOWN                 1036
+#define IDC_SET_DLEFT                   1037
+#define IDC_LABEL_DLEFT                 1038
+#define IDC_SET_DRIGHT                  1039
+#define IDC_LABEL_DRIGHT                1040
+#define IDC_SET_NUON                    1041
+#define IDC_LABEL_NUON                  1042
+#define IDC_SET_START                   1043
+#define IDC_LABEL_START                 1044
+#define IDC_SET_CUP                     1045
+#define IDC_LABEL_CUP                   1046
+#define IDC_SET_CDOWN                   1047
+#define IDC_LABEL_CDOWN                 1048
+#define IDC_SET_L                       1049
+#define IDC_JOYSTICK_COMBO              1050
+#define IDC_SET_CLEFT                   1051
+#define IDC_LABEL_CLEFT                 1052
+#define IDC_SET_CRIGHT                  1053
+#define IDC_LABEL_CRIGHT                1054
+#define IDC_BUTTON2                     1056
+#define IDC_SET_A                       1061
+#define IDC_LABEL_A                     1062
+#define IDC_SET_B                       1063
+#define IDC_LABEL_B                     1064
+#define IDC_LABEL_L                     1066
+#define IDC_SET_R                       1067
+#define IDC_LABEL_R                     1068
+#define IDC_LABEL_ANALOGX               1069
+#define IDC_LABEL_ANALOGY               1070
+#define IDC_STATIC                      -1
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
-#define _APS_NEXT_RESOURCE_VALUE        128
+#define _APS_NEXT_RESOURCE_VALUE        130
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1022
+#define _APS_NEXT_CONTROL_VALUE         1057
 #define _APS_NEXT_SYMED_VALUE           103
 #endif
 #endif

--- a/Readme.txt
+++ b/Readme.txt
@@ -367,7 +367,8 @@ second that are now available for use by the processor emulation thread.
 
 Joystick support:
 
-The keyboard may be used to control Controller slots 0 and 1 using the following keys:
+By default, the keyboard may be used to control Controller slots 0 and 1 using
+the following keys:
 
 A: Button Start
 S: Button Nuon/Z
@@ -384,6 +385,58 @@ Down: DPad Down
 Left: Dpad Left
 Right: DPad Right
 Z: switch between controller 0 and controller 1
+
+The default controller bindings can be modified by including a
+[Controller1Mappings] section in the configuration file, followed by a list of
+<Nuon Controller button> = <joystick or keyboard binding> pairs. The available
+controller button names are:
+
+CPAD_UP
+CPAD_RIGHT
+CPAD_DOWN
+CPAD_LEFT
+A
+B
+L
+R
+DPAD_UP
+DPAD_RIGHT
+DPAD_DOWN
+DPAD_LEFT
+NUON
+START
+
+The format for joystick/keyboard bindings is:
+
+<type>_<index>_<subindex>
+
+Where <type> can be:
+
+KEY - A keyboard key
+JOYBUT - Joystick button
+JOYAXIS - Joystick axis, usuallly an analog stick axis.
+JOYPOV - Joystick point of view direction, e.g., a D-pad button.
+
+<index> can take on the following values, depending on <type>:
+
+KEY - A win32 Virtual Keycode. See
+    https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+    for a list of valid values. Note the value must be in decimal, not hex.
+JOYBUT - A Joystick button number.
+JOYAXIS - A Joystick axis index.
+JOYPOV - A Joystick POV control index. Usually 0.
+
+<subindex> cantake on the following values, depending on <type>:
+
+KEY - Must be '0'
+JOYBUT - Must be '0'
+JOYAXIS - '0' = axis min direction, '1' = axis max direction
+JOYPOV - '0' = up, '1' = right, '2' = down, '3' = left.
+
+To figure which buttons/controls are which, you can use the "Properties"
+button on the "Set up USB game controllers" control panel widget. Note the
+buttons in the config file are indexed from zero, while the numbering in the
+control panel widget starts at 1.
 
 Aries version:
 

--- a/glwindow.h
+++ b/glwindow.h
@@ -2,6 +2,7 @@
 #define GLWindowH
 
 #include "basetypes.h"
+#include "InputManager.h"
 #include <windows.h>
 
 #define bUseSeparateThread false
@@ -39,11 +40,13 @@ public:
   void MessagePump();
   void ToggleFullscreen();
   void UpdateRestoreValues();
+  InputManager* GetInputManager() { return inputManager; }
 
   GLWINDOW_KEYCALLBACK keyDownHandler;
   GLWINDOW_KEYCALLBACK keyUpHandler;
   GLWINDOW_RESIZECALLBACK resizeHandler;
   GLWINDOW_CALLBACK paintHandler;
+  InputManager::CONTROLLER_CALLBACK applyControllerState;
 
 private:
   void OnResize(int _width, int _height);
@@ -60,6 +63,8 @@ private:
 
   uint32 windowStyle, windowExtendedStyle;
   uint32 fullScreenWindowStyle, fullScreenWindowExtendedStyle;
+
+  InputManager *inputManager;
 
   int restoreWidth;
   int restoreHeight;

--- a/joystick.h
+++ b/joystick.h
@@ -165,6 +165,8 @@ struct ControllerData
 //restore pushed alignment
 #pragma pack(pop)
 
+class MPE;
+
 void ControllerInitialize(MPE &mpe);
 void DeviceDetect(MPE &mpe);
 

--- a/nuance.cfg
+++ b/nuance.cfg
@@ -27,3 +27,54 @@ Disabled
 ;NOTE: This does not seem to be needed nowadays anymore, but i left it in for now, lets see
 [T3KCompilerHack]
 Disabled
+
+;Available bindings are DPAD_[UP,DOWN,LEFT,RIGHT], CPAD_[UP,DOWN,LEFT,RIGHT], A, L, R, NUON, and START.
+;Bindings can be set to KEY_<vkey_num>_0, JOYBUT_<num>_0, JOYAXIS_<axisnum>_[0,1], and JOYPOV_<POVNUM>_[0,1,2,3]
+;See win32 documentation for VKEY definitions. Regular character/number vkey values are the same as their uppercase ASCII values.
+[Controller1Mappings]
+; Default keyboard config Nuance has always shipped with:
+; '3' key
+CPAD_UP = KEY_51_0
+; 'R' key
+CPAD_RIGHT = KEY_82_0
+; 'E' key
+CPAD_DOWN = KEY_69_0
+; 'W' key
+CPAD_LEFT = KEY_87_0
+; 'D' key
+A = KEY_68_0
+; 'F' key
+B = KEY_70_0
+; 'Q' key
+L = KEY_81_0
+; 'T' key
+R = KEY_84_0
+; Up-arrow key
+DPAD_UP = KEY_38_0
+; Right-arrow key
+DPAD_RIGHT = KEY_39_0
+; Down-arrow key
+DPAD_DOWN = KEY_40_0
+; Left-arrow key
+DPAD_LEFT = KEY_37_0
+; 'S' key
+NUON = KEY_83_0
+; 'A' key
+START = KEY_65_0
+
+; Mappings for the LogitechWingMan Action Pad w/Mode light lit (analog enable):
+;CPAD_UP = JOYBUT_5_0
+;CPAD_RIGHT = JOYBUT_2_0
+;CPAD_DOWN = JOYBUT_1_0
+;CPAD_LEFT = JOYBUT_4_0
+;A = JOYBUT_0_0
+;B = JOYBUT_3_0
+;L = JOYBUT_6_0
+;R = JOYBUT_7_0
+;DPAD_UP = JOYPOV_0_0
+;DPAD_RIGHT = JOYPOV_0_1
+;DPAD_DOWN = JOYPOV_0_2
+;DPAD_LEFT = JOYPOV_0_3
+; No good button to map to Nuon button. Leave assigned to 'S' on Keyboard.
+;NUON = KEY_83_0
+;START = JOYBUT_8_0


### PR DESCRIPTION
This change adds DirectInput support, a dialog
for configuring the key bindings and joystick
bindings for the emulated controller, and support
for saving and loading the key and joystick
bindings to and from the nuance.cfg file.

-InputManager class is added to manage all the
 keyboard and DirectInput initialization and
 processing.

-ControllerButtonMapping class is added to
 encapsulate the keyboard or joystick action
 that triggers a given emulated controller
 button press.

-The NuonEnvironment class now tracks the
 joystick and keyboard bindings for each
 controller bitnum in the Nuon controller
 bitfield.

-The SaveConfigFile method is added to the
 NuonEnvironment class to handle serializing the
 configuration data back out to a config file.

-A controller configuration GUI dialog box is
 added to allow users to view and modify the
 current key and joystick bindings.

-A button to access the controller config dialog
 is added to the existing control panel dialog.