### PR TITLE
Fix user breakpoints and 16/16z pixel format bilinear dma

### DIFF
--- a/GLWindow.cpp
+++ b/GLWindow.cpp
@@ -6,13 +6,12 @@
 #include "external\glew-2.2.0\include\GL\glew.h"
 #include <GL/gl.h>
 #include "GLWindow.h"
+#include "NuanceMain.h"
 #include "video.h"
 
 /****************************************************************************
 OpenGL Window Code
 ****************************************************************************/
-
-extern bool bQuit;
 
 extern vidTexInfo videoTexInfo;
 

--- a/Nuance.vcxproj
+++ b/Nuance.vcxproj
@@ -363,6 +363,7 @@
     <ClInclude Include="FlashEEPROM.h" />
     <ClInclude Include="GLWindow.h" />
     <ClInclude Include="Handlers.h" />
+    <ClInclude Include="NuanceMain.h" />
     <ClInclude Include="InputManager.h" />
     <ClInclude Include="InstructionCache.h" />
     <ClInclude Include="InstructionDependencies.h" />

--- a/Nuance.vcxproj.filters
+++ b/Nuance.vcxproj.filters
@@ -464,6 +464,9 @@
     <ClInclude Include="InputManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="NuanceMain.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="bitmap1.bmp">

--- a/NuanceMain.cpp
+++ b/NuanceMain.cpp
@@ -328,6 +328,16 @@ static void ExecuteSingleStep()
     DoCommBusController();
 }
 
+void StopEmulation()
+{
+  EnableWindow(cbStop, FALSE);
+  EnableWindow(cbSingleStep, TRUE);
+  EnableWindow(cbLoadFile, FALSE);
+  EnableWindow(cbRun, TRUE);
+  bRun = false;
+  UpdateControlPanelDisplay();
+}
+
 INT_PTR CALLBACK StatusWindowDialogProc(HWND hwndDlg,UINT msg,WPARAM wParam,LPARAM lParam)
 {
   switch(msg)
@@ -828,12 +838,7 @@ INT_PTR CALLBACK ControlPanelDialogProc(HWND hwndDlg,UINT msg,WPARAM wParam,LPAR
           }
           else if((HWND)lParam == cbStop)
           {
-            EnableWindow(cbStop,FALSE);
-            EnableWindow(cbSingleStep,TRUE);
-            EnableWindow(cbLoadFile,FALSE);
-            EnableWindow(cbRun,TRUE);
-            bRun = false;
-            UpdateControlPanelDisplay();
+            StopEmulation();
 
             return TRUE;
           }

--- a/NuanceMain.h
+++ b/NuanceMain.h
@@ -1,0 +1,7 @@
+#ifndef NUANCE_MAIN_H
+#define NUANCE_MAIN_H
+
+extern bool bQuit;
+extern void StopEmulation();
+
+#endif

--- a/bdma_type5.cpp
+++ b/bdma_type5.cpp
@@ -251,7 +251,7 @@ void BDMA_Type5_Read_0(MPE& mpe, const uint32 flags, const uint32 baseaddr, cons
   //const uint32 type = (flags >> 14) & 0x03UL;
   //const uint32 mode = flags & 0xFFFUL;
   const uint32 zcompare = (flags >> 1) & 0x07UL;
-  //const uint32 pixtype = (flags >> 4) & 0x0FUL;
+  const uint32 pixtype = (flags >> 4) & 0x0FUL;
   //const uint32 bva = ((flags >> 7) & 0x06UL) | (flags & 0x01UL);
   const uint32 sdramBase = baseaddr & 0x7FFFFFFEUL;
   const uint32 mpeBase = intaddr & 0x7FFFFFFCUL;
@@ -260,8 +260,8 @@ void BDMA_Type5_Read_0(MPE& mpe, const uint32 flags, const uint32 baseaddr, cons
   const uint32 ylen = (yinfo >> 16) & 0x3FFUL;
   const uint32 ypos = yinfo & 0x7FFUL;
 
-  /*uint32 map = 0;
-  uint32 zmap;
+  uint32 map = 0;
+  uint32 zmap = 1;
 
   if(pixtype >= 13)
   {
@@ -274,6 +274,7 @@ void BDMA_Type5_Read_0(MPE& mpe, const uint32 flags, const uint32 baseaddr, cons
     zmap = 3;
   }
 
+  /*
   bool bCompareZ, bUpdatePixel;
   bool bUpdateZ = (zcompare != 7);
   uint8 srcStrideShift;
@@ -338,14 +339,12 @@ void BDMA_Type5_Read_0(MPE& mpe, const uint32 flags, const uint32 baseaddr, cons
   const int32 destBStep = xlen;
 
   const uint32 srcOffset = ypos * (uint32)xsize + xpos;
-  const uint32* const pSrc32 = ((uint32 *)pSrc) + srcOffset;
-  const uint16* const pSrc16 = ((uint16 *)pSrc) + srcOffset;
+  const uint16* pSrcColor = (uint16*)pSrc + (xsize * structMainChannel.src_height * map + srcOffset);
+  const uint16* pSrcZ = (uint16 *)pSrc + (xsize * structMainChannel.src_height * zmap + srcOffset);
 
   //const uint32 destOffset = 0;
   uint16* const pDest16 = (uint16 *)pDest;
   //pDest16 += destOffset;
-  uint32* const pDest32 = (uint32 *)pDest;
-  //pDest32 += destOffset;
 
   uint32 srcB = 0;
   uint32 destB = 0;
@@ -361,7 +360,7 @@ void BDMA_Type5_Read_0(MPE& mpe, const uint32 flags, const uint32 baseaddr, cons
 
       while(aCount--)
       {
-        pDest16[destA] = pSrc16[srcA];
+        pDest16[destA] = pSrcColor[srcA];
 
         srcA += srcAStep;
         destA += destAStep;
@@ -381,11 +380,11 @@ void BDMA_Type5_Read_0(MPE& mpe, const uint32 flags, const uint32 baseaddr, cons
 
       while(aCount--)
       {
-        pDest32[destA] = pSrc32[srcA];
-        //((uint16 *)(&pDest32[destA]))[0] = ((uint16 *)(&pSrc32[srcA]))[0];
+        pDest16[destA] = pSrcColor[srcA];
+        pDest16[destA + 1] = pSrcZ[srcA];
 
         srcA += srcAStep;
-        destA += destAStep;
+        destA += (destAStep << 1);
       }
 
       srcB += srcBStep;

--- a/dma.cpp
+++ b/dma.cpp
@@ -378,7 +378,7 @@ constexpr BilinearDMAHandler BilinearDMAHandlers[] =
   UnimplementedBilinearDMAHandler,
 //Read
   //Horizontal, A = 0, B = 0
-  UnimplementedBilinearDMAHandler,
+  BDMA_Type5_Read_0,
   //Horizontal, A = 1, B = 0
   UnimplementedBilinearDMAHandler,
   //Vertical, A = 0, B = 0
@@ -413,7 +413,7 @@ constexpr BilinearDMAHandler BilinearDMAHandlers[] =
   UnimplementedBilinearDMAHandler,
 //Read
   //Horizontal, A = 0, B = 0
-  UnimplementedBilinearDMAHandler,
+  BDMA_Type5_Read_0,
   //Horizontal, A = 1, B = 0
   UnimplementedBilinearDMAHandler,
   //Vertical, A = 0, B = 0
@@ -448,7 +448,7 @@ constexpr BilinearDMAHandler BilinearDMAHandlers[] =
   UnimplementedBilinearDMAHandler,
 //Read
   //Horizontal, A = 0, B = 0
-  UnimplementedBilinearDMAHandler,
+  BDMA_Type5_Read_0,
   //Horizontal, A = 1, B = 0
   UnimplementedBilinearDMAHandler,
   //Vertical, A = 0, B = 0
@@ -518,7 +518,7 @@ constexpr BilinearDMAHandler BilinearDMAHandlers[] =
   UnimplementedBilinearDMAHandler,
 //Read
   //Horizontal, A = 0, B = 0
-  UnimplementedBilinearDMAHandler,
+  BDMA_Type5_Read_0,
   //Horizontal, A = 1, B = 0
   UnimplementedBilinearDMAHandler,
   //Vertical, A = 0, B = 0
@@ -553,7 +553,7 @@ constexpr BilinearDMAHandler BilinearDMAHandlers[] =
   UnimplementedBilinearDMAHandler,
 //Read
   //Horizontal, A = 0, B = 0
-  UnimplementedBilinearDMAHandler,
+  BDMA_Type5_Read_0,
   //Horizontal, A = 1, B = 0
   UnimplementedBilinearDMAHandler,
   //Vertical, A = 0, B = 0

--- a/mpe.cpp
+++ b/mpe.cpp
@@ -34,6 +34,7 @@
 #include "SuperBlock.h"
 #include "X86EmitTypes.h"
 #include "Utility.h"
+#include "NuanceMain.h"
 
 #define LOG_MPE_INDEX (1)
 
@@ -2213,7 +2214,10 @@ bool MPE::FetchDecodeExecute()
       }
     }
 
-    if((excephalten & excepsrc) || (pcexec == breakpointAddress))
+    if (pcexec == breakpointAddress)
+      StopEmulation();
+
+    if((excephalten & excepsrc))
       Halt();
 
     //StopPerformanceTimer();


### PR DESCRIPTION
See the individual commit messages for details. This pair of changes fixes two issues I ran into debugging my app tonight:

* Bilinear DMA reads of 16 bit color + 16 bit Z double and triple buffer pixel formats weren't supported even though writes were.
* The user breakpoint mechanism wasn't terribly usable in practice.