### PR TITLE
Restore ability to switch "disassembly MPE"

### DIFF
--- a/Nuance.rc
+++ b/Nuance.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "windows.h"
+#include "afxres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -77,10 +77,10 @@ BEGIN
     CONTROL         IDB_LED_OFF,IDC_MPE1_LED,"Static",SS_BITMAP | SS_NOTIFY | WS_TABSTOP,5,26,19,16
     CONTROL         IDB_LED_OFF,IDC_MPE2_LED,"Static",SS_BITMAP | SS_NOTIFY | WS_TABSTOP,5,42,19,16
     CONTROL         IDB_LED_OFF,IDC_MPE3_LED,"Static",SS_BITMAP | SS_NOTIFY | WS_TABSTOP,5,57,19,16
-    LTEXT           "mpe0:",IDC_LABEL_MPE0,32,15,21,8
-    LTEXT           "mpe1:",IDC_LABEL_MPE1,32,31,21,8
-    LTEXT           "mpe2:",IDC_LABEL_MPE2,32,47,21,8
-    LTEXT           "mpe3:",IDC_LABEL_MPE3,32,62,21,8
+    LTEXT           "mpe0:",IDC_LABEL_MPE0,32,15,21,8,SS_NOTIFY
+    LTEXT           "mpe1:",IDC_LABEL_MPE1,32,31,21,8,SS_NOTIFY
+    LTEXT           "mpe2:",IDC_LABEL_MPE2,32,47,21,8,SS_NOTIFY
+    LTEXT           "mpe3:",IDC_LABEL_MPE3,32,62,21,8,SS_NOTIFY
     LTEXT           "$80010000",IDC_MPE0_PCEXEC,56,15,37,8
     LTEXT           "$80010000",IDC_MPE1_PCEXEC,56,31,37,8
     LTEXT           "$80010000",IDC_MPE3_PCEXEC,56,62,37,8

--- a/NuanceMain.cpp
+++ b/NuanceMain.cpp
@@ -328,14 +328,20 @@ static void ExecuteSingleStep()
     DoCommBusController();
 }
 
-void StopEmulation()
+static void SetDisassemblyMPE(int mpeIndex)
+{
+  disassemblyMPE = mpeIndex;
+  UpdateControlPanelDisplay();
+}
+
+void StopEmulation(int mpeIndex)
 {
   EnableWindow(cbStop, FALSE);
   EnableWindow(cbSingleStep, TRUE);
   EnableWindow(cbLoadFile, FALSE);
   EnableWindow(cbRun, TRUE);
   bRun = false;
-  UpdateControlPanelDisplay();
+  SetDisassemblyMPE(mpeIndex);
 }
 
 INT_PTR CALLBACK StatusWindowDialogProc(HWND hwndDlg,UINT msg,WPARAM wParam,LPARAM lParam)
@@ -816,7 +822,7 @@ INT_PTR CALLBACK ControlPanelDialogProc(HWND hwndDlg,UINT msg,WPARAM wParam,LPAR
     case WM_COMMAND:
       switch(HIWORD(wParam))
       {
-        case BN_CLICKED:
+        case BN_CLICKED: /* Alias for STN_CLICKED */
           if((HWND)lParam == cbRun)
           {
             Run();
@@ -838,7 +844,7 @@ INT_PTR CALLBACK ControlPanelDialogProc(HWND hwndDlg,UINT msg,WPARAM wParam,LPAR
           }
           else if((HWND)lParam == cbStop)
           {
-            StopEmulation();
+            StopEmulation(disassemblyMPE);
 
             return TRUE;
           }
@@ -874,23 +880,19 @@ INT_PTR CALLBACK ControlPanelDialogProc(HWND hwndDlg,UINT msg,WPARAM wParam,LPAR
           }
           else if((HWND)lParam == textMPE0)
           {
-            disassemblyMPE = 0;
-            UpdateControlPanelDisplay();
+            SetDisassemblyMPE(0);
           }
           else if((HWND)lParam == textMPE1)
           {
-            disassemblyMPE = 1;
-            UpdateControlPanelDisplay();
+            SetDisassemblyMPE(1);
           }
           else if((HWND)lParam == textMPE2)
           {
-            disassemblyMPE = 2;
-            UpdateControlPanelDisplay();
+            SetDisassemblyMPE(2);
           }
           else if((HWND)lParam == textMPE3)
           {
-            disassemblyMPE = 3;
-            UpdateControlPanelDisplay();
+            SetDisassemblyMPE(3);
           }
           return TRUE;
         case STN_DBLCLK:

--- a/NuanceMain.h
+++ b/NuanceMain.h
@@ -2,6 +2,6 @@
 #define NUANCE_MAIN_H
 
 extern bool bQuit;
-extern void StopEmulation();
+extern void StopEmulation(int mpeIndex);
 
 #endif

--- a/mpe.cpp
+++ b/mpe.cpp
@@ -2215,7 +2215,7 @@ bool MPE::FetchDecodeExecute()
     }
 
     if (pcexec == breakpointAddress)
-      StopEmulation();
+      StopEmulation(mpeIndex);
 
     if((excephalten & excepsrc))
       Halt();


### PR DESCRIPTION
The control panel dialog will disassemble and
display the next instruction packet for the
currently selected "disassembly MPE" which is
initialized to MPE 3. There was code to switch
this to any MPE when that MPE's text label on the
side of the dialog was clicked, but it was broken
because the corresponding static text controls did not have the "Notify" style set on them in the
corresponding resource file. Fixing up the style
allows this to work again.

As a bonus, this change also modifies the prior
improved breakpoint handling change to
automatically switch the disassembly MPE to
whichever MPE triggered the breakpoint when a
breakpoint is hit.