### PR TITLE
Extract shared EmulatorCore for Linux/libretro frontends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ set(NUANCE_SOURCES
     src/MPEControlRegisters.cpp
     src/mpe_alloc.cpp
     src/nativecodecache.cpp
+    src/EmulatorCore.cpp
     $<IF:$<PLATFORM_ID:Windows>,src/NuanceMain.cpp,src/NuanceMain_linux.cpp>
     src/NuonEnvironment.cpp
     src/NuonMemoryManager.cpp
@@ -171,11 +172,18 @@ if(BUILD_LIBRETRO)
     target_compile_definitions(nuance_libretro PRIVATE LIBRETRO)
     set(NUANCE_TARGET nuance_libretro)
 else()
- if(NOT WIN32)
-    add_executable(nuance ${NUANCE_SOURCES})
- else()
-    add_executable(nuance WIN32 ${NUANCE_SOURCES})
- endif()
+    # Windows standalone keeps NuanceMain.cpp's legacy globals
+    # (nuonEnv/bQuit/g_ISOPath/g_ISOPrefix/StopEmulation). EmulatorCore.cpp
+    # defines the same names for the libretro and Linux-standalone frontends,
+    # so drop it on Windows to avoid duplicate-symbol link errors.
+    if(WIN32)
+        list(FILTER NUANCE_SOURCES EXCLUDE REGEX "EmulatorCore")
+    endif()
+    if(NOT WIN32)
+        add_executable(nuance ${NUANCE_SOURCES})
+    else()
+        add_executable(nuance WIN32 ${NUANCE_SOURCES})
+    endif()
     set(NUANCE_TARGET nuance)
 endif()
 
@@ -243,6 +251,8 @@ target_link_libraries(${NUANCE_TARGET} PRIVATE
     # libretro build infra passes SDL2_LIBRARIES as a raw `sdl2-config --libs`
     # string (e.g. "-L/usr/lib/... -lSDL2 ") that has trailing whitespace.
     $<$<NOT:$<BOOL:${BUILD_LIBRETRO}>>:${SDL2_LIBRARIES}>
+    # pthread / libdl are POSIX-only; MinGW uses Win32 threads and resolves
+    # dlopen-style calls via the C runtime / LoadLibrary
     $<$<NOT:$<PLATFORM_ID:Windows>>:pthread>
     $<$<NOT:$<PLATFORM_ID:Windows>>:dl>
     $<$<NOT:$<PLATFORM_ID:Windows>>:m>

--- a/src/EmulatorCore.cpp
+++ b/src/EmulatorCore.cpp
@@ -1,0 +1,174 @@
+// Shared NUON emulator core. See EmulatorCore.h for the API contract.
+#include "EmulatorCore.h"
+
+#include "Utility.h"
+#include "ExecuteMEM.h"
+#include "comm.h"
+#include "byteswap.h"
+#include "mpe.h"
+#include "video.h"
+#include "timer.h"
+#include "Bios.h"
+#include "NuonMemoryMap.h"
+#include "joystick.h"
+#include "archive.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+// Definitions of the single-instance globals declared in EmulatorCore.h.
+// These used to live (duplicated) in each frontend translation unit.
+NuonEnvironment nuonEnv;
+bool bQuit = false;
+bool bRun  = false;
+std::string g_ISOPath;
+std::string g_ISOPrefix;
+
+extern ControllerData* controller;
+
+// Satisfies the `extern void StopEmulation(int)` declaration in NuanceMain.h.
+void StopEmulation(int /*mpeIndex*/)
+{
+    bRun = false;
+}
+
+namespace EmulatorCore {
+
+void Init()
+{
+    init_supported_CPU_extensions();
+    GenerateMirrorLookupTable();
+    GenerateSaturateColorTables();
+    nuonEnv.Init();
+}
+
+bool LoadGame(const char* path)
+{
+    if (!path)
+        return false;
+
+    static bool s_loadedOnce = false;
+    if (s_loadedOnce)
+        nuonEnv.ResetForReload();
+
+    bool ok = nuonEnv.mpe[3].LoadNuonRomFile(path);
+    if (!ok)
+        ok = nuonEnv.mpe[3].LoadCoffFile(path);
+    if (!ok)
+        return false;
+    nuonEnv.SetDVDBaseFromFileName(path);
+    nuonEnv.mpe[3].Go();
+    s_loadedOnce = true;
+    return true;
+}
+
+void ApplyController(unsigned controllerIdx, uint16 buttons)
+{
+    if (controller)
+        controller[controllerIdx].buttons = SwapBytes(buttons);
+}
+
+uint32 RunUntilVideoFrame(uint64 budget_us, bool push_audio)
+{
+    // Wall-time anchors for the three Nuon system timers and the audio push
+    // cadence. Static so the schedule survives across calls (each call is
+    // one video field of work).
+    static uint64 last_time0 = useconds_since_start();
+    static uint64 last_time1 = useconds_since_start();
+    static uint64 last_time2 = useconds_since_start();
+    static uint64 last_time3 = useconds_since_start();
+
+    const uint64 entry_us = useconds_since_start();
+    uint32 cycles = 0;
+    while (bRun && !nuonEnv.trigger_render_video) {
+        cycles++;
+
+        for (int i = 3; i >= 0; --i)
+            if (i != 3 || nuonEnv.MPE3wait_fieldCounter == 0)
+                nuonEnv.mpe[i].FetchDecodeExecute();
+
+        if (nuonEnv.pendingCommRequests)
+            DoCommBusController();
+
+        if ((cycles % 500) == 0) {
+            const uint64 now = useconds_since_start();
+
+            // Libretro frame budget: return control to retroarch even if
+            // no video field fired yet, so the host frontend can drive
+            // its own 60Hz pacing.
+            if (budget_us > 0 && (now - entry_us) >= budget_us)
+                break;
+
+            if (nuonEnv.timer_rate[0] > 0) {
+                if (now >= last_time0 + (uint64)nuonEnv.timer_rate[0]) {
+                    nuonEnv.ScheduleInterrupt(INT_SYSTIMER0);
+                    last_time0 = now;
+                }
+            } else {
+                last_time0 = now;
+            }
+
+            if (nuonEnv.timer_rate[1] > 0) {
+                if (now >= last_time1 + (uint64)nuonEnv.timer_rate[1]) {
+                    nuonEnv.ScheduleInterrupt(INT_SYSTIMER1);
+                    last_time1 = now;
+                }
+            } else {
+                last_time1 = now;
+            }
+
+            if (nuonEnv.timer_rate[2] > 0) {
+                if (now >= last_time2 + (uint64)nuonEnv.timer_rate[2]) {
+                    IncrementVideoFieldCounter();
+                    nuonEnv.TriggerVideoInterrupt();
+                    nuonEnv.trigger_render_video = true;
+                    const uint32 fieldCounter = SwapBytes(*((uint32*)&nuonEnv.systemBusDRAM[VIDEO_FIELD_COUNTER_ADDRESS & SYSTEM_BUS_VALID_MEMORY_MASK]));
+                    if (fieldCounter >= nuonEnv.MPE3wait_fieldCounter)
+                        nuonEnv.MPE3wait_fieldCounter = 0;
+                    last_time2 = now;
+                }
+            } else {
+                last_time2 = now;
+            }
+
+            // Audio period push. Both frontends produce here (standalone's
+            // miniaudio device and libretro's DrainAudioRing are the consumers).
+            // Gated on a channel-mode toggle so we only push when NISE is
+            // actively ping-ponging buffers; the INT_AUDIO mask check avoids
+            // pushing while a previous period is still being acknowledged.
+            // The pacing interval is the period's TRUE playback duration at the
+            // Nuon rate (AudioPeriodIntervalUs), not the 60Hz video field: a
+            // period is half the game-chosen DMA buffer (1K..64K), so pacing on
+            // the field overproduces for >4K buffers (RetroArch audio_sync then
+            // throttles the whole frontend -> slowdown) and underruns for <4K.
+            if (push_audio) {
+                const uint64 audioIntervalUs = nuonEnv.AudioPeriodIntervalUs();
+                if (audioIntervalUs > 0) {
+                    if (nuonEnv.pNuonAudioBuffer &&
+                        (now >= last_time3 + audioIntervalUs) &&
+                        ((nuonEnv.nuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT)) != (nuonEnv.oldNuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT))) &&
+                        ((((nuonEnv.mpe[0].intsrc & nuonEnv.mpe[0].inten1) |
+                           (nuonEnv.mpe[1].intsrc & nuonEnv.mpe[1].inten1) |
+                           (nuonEnv.mpe[2].intsrc & nuonEnv.mpe[2].inten1) |
+                           (nuonEnv.mpe[3].intsrc & nuonEnv.mpe[3].inten1)) & INT_AUDIO) == 0)) {
+                        if (nuonEnv.TryPushAudioPeriod())
+                            last_time3 = now;
+                    }
+                } else {
+                    last_time3 = now;
+                }
+            }
+        }
+
+        nuonEnv.TriggerScheduledInterrupts();
+    }
+    return cycles;
+}
+
+void Shutdown()
+{
+    VideoCleanup();
+    CleanupArchives();
+}
+
+} // namespace EmulatorCore

--- a/src/EmulatorCore.h
+++ b/src/EmulatorCore.h
@@ -1,0 +1,44 @@
+// Shared NUON emulator core used by both the standalone Linux frontend
+// (NuanceMain_linux.cpp) and the libretro core (libretro.cpp). Each
+// frontend handles its own windowing / input / audio sink and just
+// drives the emulator through this API.
+#ifndef EMULATOR_CORE_H
+#define EMULATOR_CORE_H
+
+#include "basetypes.h"
+#include "NuanceMain.h"   // extern bool bQuit; extern void StopEmulation(int);
+#include "NuonEnvironment.h"
+#include <string>
+
+extern NuonEnvironment nuonEnv;
+extern bool bRun;
+extern std::string g_ISOPath;
+extern std::string g_ISOPrefix;
+
+namespace EmulatorCore {
+
+// CPU extension probe, ALU lookup tables, NuonEnvironment::Init.
+void Init();
+
+// LoadNuonRomFile -> LoadCoffFile fallback, SetDVDBaseFromFileName, MPE3 Go.
+// Returns false if neither loader recognised the file.
+bool LoadGame(const char* path);
+
+// Byte-swap and write to controller[controllerIdx].buttons. Safe pre-Init.
+void ApplyController(unsigned controllerIdx, uint16 buttons);
+
+// Drive all 4 MPEs until trigger_render_video is set or, if budget_us > 0,
+// until that many microseconds of wall time have elapsed since entry.
+// push_audio = also push one Nuon audio period to the host ring per video
+// field (the standalone build's miniaudio sink consumes those periods;
+// libretro uses DrainAudioRing from retro_run instead and passes false).
+// Returns the number of inner-loop iterations executed in this call,
+// useful for the standalone frontend's FPS / kHz title-bar readout.
+uint32 RunUntilVideoFrame(uint64 budget_us, bool push_audio);
+
+// VideoCleanup + CleanupArchives. Idempotent on second call.
+void Shutdown();
+
+} // namespace EmulatorCore
+
+#endif // EMULATOR_CORE_H

--- a/src/NuanceMain_linux.cpp
+++ b/src/NuanceMain_linux.cpp
@@ -1,4 +1,7 @@
-// NuanceMain implementation for Linux
+// Standalone Linux frontend for the NUON emulator. The emulator loop,
+// globals and load/init helpers live in EmulatorCore (shared with the
+// libretro core in libretro.cpp); this file only handles the X11/SDL2
+// window and the title-bar FPS readout.
 #ifndef _WIN32
 
 #include "basetypes.h"
@@ -18,6 +21,7 @@
 #include "GLWindow.h"
 #include "audio.h"
 #include "mpe.h"
+#include "EmulatorCore.h"
 #include "NuonEnvironment.h"
 #include "NuonMemoryMap.h"
 #include "NuanceRes.h"
@@ -29,8 +33,6 @@
 #include "NuanceUI.h"
 #include "archive.h"
 
-NuonEnvironment nuonEnv;
-
 extern ControllerData *controller;
 extern std::mutex gfx_lock;
 extern VidChannel structMainChannel, structOverlayChannel;
@@ -39,11 +41,7 @@ extern vidTexInfo videoTexInfo;
 
 extern void SDL2_SwapWindow();
 
-bool bQuit = false;
-bool bRun = false;
-std::string g_ISOPath;          // path to mounted ISO (for reading data files)
-std::string g_ISOPrefix;        // NUON directory name inside ISO (e.g. "NUON")
-std::string g_LastLoadedPath;   // original argv path (for Reset → re-Load same game)
+std::string g_LastLoadedPath;
 static bool load4firsttime = true;
 
 GLWindow display;
@@ -69,11 +67,6 @@ static void ExecuteSingleStep()
   nuonEnv.mpe[0].ExecuteSingleStep();
   if(nuonEnv.pendingCommRequests)
     DoCommBusController();
-}
-
-void StopEmulation(int mpeIndex)
-{
-  bRun = false;
 }
 
 bool OnDisplayPaint(WPARAM, LPARAM)
@@ -113,8 +106,7 @@ bool OnDisplayResize(uint16 width, uint16 height)
 
 static void ApplyControllerState(const unsigned int controllerIdx, const uint16 buttons)
 {
-  if (controller)
-    controller[controllerIdx].buttons = SwapBytes(buttons);
+  EmulatorCore::ApplyController(controllerIdx, buttons);
 }
 
 static void Run()
@@ -141,29 +133,14 @@ bool Load(const char* file)
     return false;
   }
 
-  static bool s_loadedOnce = false;
-  if (s_loadedOnce)
-    nuonEnv.ResetForReload();
-
-  // Try loading as NUONROM-DISK/Bles first, then as raw COFF
-  bool bSuccess = nuonEnv.mpe[3].LoadNuonRomFile(actualFile.c_str());
-  if (!bSuccess) {
-    bSuccess = nuonEnv.mpe[3].LoadCoffFile(actualFile.c_str());
-    if (!bSuccess) {
-      fprintf(stderr, "Cannot open file or Invalid COFF/NUONROM-DISK/Bles file: %s\n", actualFile.c_str());
-      return false;
-    }
+  if (!EmulatorCore::LoadGame(actualFile.c_str())) {
+    fprintf(stderr, "Cannot open file or Invalid COFF/NUONROM-DISK/Bles file: %s\n", actualFile.c_str());
+    return false;
   }
   fprintf(stderr, "Loaded successfully: %s\n", actualFile.c_str());
 
-  if (bSuccess) {
-    nuonEnv.SetDVDBaseFromFileName(actualFile.c_str());
-    nuonEnv.mpe[3].Go();
-    s_loadedOnce = true;
-    Run();
-    return true;
-  }
-  return false;
+  Run();
+  return true;
 }
 
 int main(int argc, char* argv[])
@@ -173,12 +150,7 @@ int main(int argc, char* argv[])
   asmjit_selftest();
 #endif
 
-  init_supported_CPU_extensions();
-
-  GenerateMirrorLookupTable();
-  GenerateSaturateColorTables();
-
-  nuonEnv.Init();
+  EmulatorCore::Init();
 
   display.applyControllerState = ApplyControllerState;
   display.resizeHandler = OnDisplayResize;
@@ -204,67 +176,11 @@ int main(int argc, char* argv[])
   {
     display.MessagePump();
 
-    uint64 cycles = 0;
-    while (bRun && !nuonEnv.trigger_render_video)
-    {
-      cycles++;
-
-      for (int i = 3; i >= 0; --i)
-        if (i != 3 || nuonEnv.MPE3wait_fieldCounter == 0)
-          nuonEnv.mpe[i].FetchDecodeExecute();
-
-      if (nuonEnv.pendingCommRequests)
-        DoCommBusController();
-
-      if ((cycles % 500) == 0)
-      {
-        static uint64 last_time0 = useconds_since_start();
-        static uint64 last_time1 = useconds_since_start();
-        static uint64 last_time2 = useconds_since_start();
-        static uint64 last_time3 = useconds_since_start();
-        const uint64 new_time = useconds_since_start();
-
-        if (nuonEnv.timer_rate[0] > 0) {
-          if (new_time >= last_time0 + (uint64)nuonEnv.timer_rate[0]) {
-            nuonEnv.ScheduleInterrupt(INT_SYSTIMER0);
-            last_time0 = new_time;
-          }
-        } else last_time0 = new_time;
-
-        if (nuonEnv.timer_rate[1] > 0) {
-          if (new_time >= last_time1 + (uint64)nuonEnv.timer_rate[1]) {
-            nuonEnv.ScheduleInterrupt(INT_SYSTIMER1);
-            last_time1 = new_time;
-          }
-        } else last_time1 = new_time;
-
-        if (nuonEnv.timer_rate[2] > 0) {
-          if (new_time >= last_time2 + (uint64)nuonEnv.timer_rate[2]) {
-            IncrementVideoFieldCounter();
-            nuonEnv.TriggerVideoInterrupt();
-            nuonEnv.trigger_render_video = true;
-            const uint32 fieldCounter = SwapBytes(*((uint32*)&nuonEnv.systemBusDRAM[VIDEO_FIELD_COUNTER_ADDRESS & SYSTEM_BUS_VALID_MEMORY_MASK]));
-            if (fieldCounter >= nuonEnv.MPE3wait_fieldCounter)
-              nuonEnv.MPE3wait_fieldCounter = 0;
-            last_time2 = new_time;
-          }
-        } else last_time2 = new_time;
-
-        // audTimer - push one Nuon audio period into the host audio ring (byte-swapped), advance the
-        // DMA half pointer, fire INT_AUDIO. Ring full -> skip this iteration
-        if (nuonEnv.timer_rate[2] > 0) {
-          if (nuonEnv.pNuonAudioBuffer &&
-              (new_time >= last_time3 + (uint64)nuonEnv.timer_rate[2]) &&
-              ((nuonEnv.nuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT)) != (nuonEnv.oldNuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT))) &&
-              ((((nuonEnv.mpe[0].intsrc & nuonEnv.mpe[0].inten1) | (nuonEnv.mpe[1].intsrc & nuonEnv.mpe[1].inten1) | (nuonEnv.mpe[2].intsrc & nuonEnv.mpe[2].inten1) | (nuonEnv.mpe[3].intsrc & nuonEnv.mpe[3].inten1)) & INT_AUDIO) == 0)) {
-            if (nuonEnv.TryPushAudioPeriod())
-              last_time3 = new_time;
-          }
-        } else last_time3 = new_time;
-      }
-
-      nuonEnv.TriggerScheduledInterrupts();
-    }
+    // Run the shared emulator loop until the next video field.
+    // Standalone: no time budget (budget_us=0), push audio periods so
+    // miniaudio's worker thread can consume them.
+    const uint64 cycles = EmulatorCore::RunUntilVideoFrame(/*budget_us=*/0,
+                                                           /*push_audio=*/true);
 
     if (nuonEnv.trigger_render_video)
     {
@@ -294,9 +210,8 @@ int main(int argc, char* argv[])
     }
   }
 
-  VideoCleanup();
   display.CleanUp();
-  CleanupArchives();
+  EmulatorCore::Shutdown();
 
   return 0;
 }

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -1,5 +1,7 @@
-// NuanceResurrection libretro core
-// Wraps the NUON emulator for use in RetroArch
+// NuanceResurrection libretro core. The emulator loop, globals and
+// load/init helpers live in EmulatorCore (shared with the standalone
+// Linux frontend in NuanceMain_linux.cpp); this file only handles the
+// libretro API surface, input mapping and game-file discovery.
 
 #include "libretro.h"
 #include "basetypes.h"
@@ -27,6 +29,7 @@
 #include "comm.h"
 #include "audio.h"
 #include "mpe.h"
+#include "EmulatorCore.h"
 #include "NuonEnvironment.h"
 #include "NuonMemoryMap.h"
 #include "joystick.h"
@@ -56,13 +59,6 @@ void GLWindow::MessagePump() {}
 void GLWindow::OnResize(int,int) {}
 unsigned GLWindow::GLWindowMain(void*) { return 0; }
 GLWindow display;
-
-// Globals
-NuonEnvironment nuonEnv;
-bool bQuit = false;
-bool bRun = false;
-std::string g_ISOPath;
-std::string g_ISOPrefix;
 
 extern ControllerData *controller;
 extern VidChannel structMainChannel, structOverlayChannel;
@@ -96,9 +92,6 @@ static void log_printf(const char* fmt, ...) {
     va_end(ap);
 }
 
-// Stub functions needed by other modules
-void StopEmulation(int) { bRun = false; }
-
 // InputManager stubs for libretro (input handled by retro_input_state)
 #include "InputManager.h"
 InputManager::~InputManager() {}
@@ -112,12 +105,6 @@ bool InputManager::StrToInputType(const char* str, InputType* type) {
 }
 const char* InputManager::InputTypeToStr(InputType type) {
     switch (type) { case KEY: return "KEY"; case JOYBUT: return "JOYBUT"; case JOYAXIS: return "JOYAXIS"; case JOYPOV: return "JOYPOV"; default: return ""; }
-}
-
-static void ApplyControllerState(unsigned int controllerIdx, uint16 buttons)
-{
-    if (controller)
-        controller[controllerIdx].buttons = SwapBytes(buttons);
 }
 
 static uint16 GetInputButtons()
@@ -163,15 +150,8 @@ static void context_reset(void)
     // one-time-init guards set and renders with stale handles -> black screen.
     VideoInvalidateGLState();
 
-    // Init CPU extensions and lookup tables (deferred from retro_load_game)
-    static bool tables_initialized = false;
-    if (!tables_initialized) {
-        init_supported_CPU_extensions();
-        GenerateMirrorLookupTable();
-        GenerateSaturateColorTables();
-        tables_initialized = true;
-        log_printf("libretro: tables initialized in context_reset\n");
-    }
+    // (CPU extensions, ALU lookup tables and nuonEnv.Init now happen
+    // unconditionally in retro_load_game via EmulatorCore::Init.)
 
     // Setup GL state
     glViewport(0, 0, FB_WIDTH, FB_HEIGHT);
@@ -352,21 +332,16 @@ bool retro_load_game(const struct retro_game_info *game)
         }
     }
 
-    log_printf("libretro: nuonEnv.Init()...\n"); fflush(stderr);
-    nuonEnv.Init();
-    log_printf("libretro: nuonEnv.Init() done\n"); fflush(stderr);
+    log_printf("libretro: EmulatorCore::Init()...\n"); fflush(stderr);
+    EmulatorCore::Init();
+    log_printf("libretro: EmulatorCore::Init() done\n"); fflush(stderr);
 
     // Load game
-    bool ok = nuonEnv.mpe[3].LoadNuonRomFile(gamePath.c_str());
-    if (!ok) ok = nuonEnv.mpe[3].LoadCoffFile(gamePath.c_str());
-    if (!ok) {
+    if (!EmulatorCore::LoadGame(gamePath.c_str())) {
         log_printf("libretro: failed to load %s\n", gamePath.c_str());
         return false;
     }
-
-    nuonEnv.SetDVDBaseFromFileName(gamePath.c_str());
     for(int i=0;i<4;i++) log_printf("libretro: mpe%d inten1=%08X inten2sel=%u intsrc=%08X intctl=%08X mpectl=%08X\n", i, nuonEnv.mpe[i].inten1, nuonEnv.mpe[i].inten2sel, nuonEnv.mpe[i].intsrc, nuonEnv.mpe[i].intctl, nuonEnv.mpe[i].mpectl); fflush(stderr);
-    nuonEnv.mpe[3].Go();
     // Process any pending comm requests from BIOS init before starting emulation
     while (nuonEnv.pendingCommRequests) {
         log_printf("libretro: processing %d pending comm requests from init\n", nuonEnv.pendingCommRequests); fflush(stderr);
@@ -385,7 +360,7 @@ void retro_unload_game(void)
 {
     bRun = false;
     game_loaded = false;
-    VideoCleanup();
+    EmulatorCore::Shutdown();
 }
 
 void retro_run(void)
@@ -394,87 +369,19 @@ void retro_run(void)
 
     // Input
     input_poll_cb();
-    uint16 buttons = GetInputButtons();
-    ApplyControllerState(1, buttons);
+    EmulatorCore::ApplyController(1, GetInputButtons());
 
-    // Run emulation until video trigger or real-time budget (~16ms for 60fps)
+    // Run shared emulator loop until the next video field, with a wall-time
+    // budget so we return control to retroarch on time for 60Hz pacing.
+    // During BIOS init (before video is configured) give the loop longer
+    // so init can finish. push_audio=true: we no longer open our own
+    // miniaudio device, so the loop produces audio periods into the ring,
+    // which DrainAudioRing below hands to audio_batch_cb.
     nuonEnv.trigger_render_video = false;
-    uint32 cycles = 0;
-    static uint64 last_time0 = useconds_since_start();
-    static uint64 last_time1 = useconds_since_start();
-    static uint64 last_time2 = useconds_since_start();
-    static uint64 last_time3 = useconds_since_start();
-    const uint64 frame_budget_start = useconds_since_start();
-    // During BIOS init (before video is configured), allow longer execution time
-    // Use 100ms budget for first 100 frames to allow BIOS init to complete
     static int init_frames = 0;
     const uint64 frame_budget_us = (init_frames < 100) ? 50000 : 16000;
     init_frames++;
-    while (bRun && !nuonEnv.trigger_render_video)
-    {
-        cycles++;
-
-        for (int i = 3; i >= 0; --i)
-            if (i != 3 || nuonEnv.MPE3wait_fieldCounter == 0)
-                nuonEnv.mpe[i].FetchDecodeExecute();
-
-        if (nuonEnv.pendingCommRequests)
-            DoCommBusController();
-
-        if ((cycles % 5000) == 0)
-        {
-            const uint64 new_time = useconds_since_start();
-            // Time-based frame budget: break after ~16ms to return control to retroarch
-            if ((new_time - frame_budget_start) >= frame_budget_us) {
-                static int flog = 0;
-                if (flog < 5) { fprintf(stderr, "FRAME[%d]: %u cycles in %lums budget=%lums\n", init_frames, cycles, (unsigned long)(new_time - frame_budget_start)/1000, (unsigned long)frame_budget_us/1000); flog++; }
-                break;
-            }
-
-            if (nuonEnv.timer_rate[0] > 0 && new_time >= last_time0 + (uint64)nuonEnv.timer_rate[0]) {
-                nuonEnv.ScheduleInterrupt(INT_SYSTIMER0); last_time0 = new_time;
-            } else if (nuonEnv.timer_rate[0] <= 0) last_time0 = new_time;
-
-            if (nuonEnv.timer_rate[1] > 0 && new_time >= last_time1 + (uint64)nuonEnv.timer_rate[1]) {
-                nuonEnv.ScheduleInterrupt(INT_SYSTIMER1); last_time1 = new_time;
-            } else if (nuonEnv.timer_rate[1] <= 0) last_time1 = new_time;
-
-            {
-                // Video field counter update: use timer_rate[2] if set, otherwise default ~60Hz (16667us)
-                const uint64 vidRate = (nuonEnv.timer_rate[2] > 0) ? (uint64)nuonEnv.timer_rate[2] : 16667;
-                if (new_time >= last_time2 + vidRate) {
-                    IncrementVideoFieldCounter();
-                    nuonEnv.TriggerVideoInterrupt();
-                    nuonEnv.trigger_render_video = true;
-                    const uint32 fieldCounter = SwapBytes(*((uint32*)&nuonEnv.systemBusDRAM[VIDEO_FIELD_COUNTER_ADDRESS & SYSTEM_BUS_VALID_MEMORY_MASK]));
-                    if (fieldCounter >= nuonEnv.MPE3wait_fieldCounter)
-                        nuonEnv.MPE3wait_fieldCounter = 0;
-                    last_time2 = new_time;
-                }
-            }
-
-            // Audio: feed the host audio ring (RetroArch drains it via
-            // DrainAudioRing below). Push one Nuon audio period when the game has
-            // re-armed its HALF/WRAP interrupt and INT_AUDIO is not already
-            // pending. The pacing interval is the period's TRUE playback duration
-            // at the Nuon rate (AudioPeriodIntervalUs), not the 60Hz video field:
-            // a period is half the game-chosen DMA buffer (1K..64K), so pacing on
-            // the field overproduces for >4K buffers (RetroArch audio_sync then
-            // throttles the whole frontend -> slowdown) and underruns for <4K.
-            const uint64 audioIntervalUs = nuonEnv.AudioPeriodIntervalUs();
-            if (audioIntervalUs > 0) {
-                if (nuonEnv.pNuonAudioBuffer &&
-                    (new_time >= last_time3 + audioIntervalUs) &&
-                    ((nuonEnv.nuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT)) != (nuonEnv.oldNuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT))) &&
-                    ((((nuonEnv.mpe[0].intsrc & nuonEnv.mpe[0].inten1) | (nuonEnv.mpe[1].intsrc & nuonEnv.mpe[1].inten1) | (nuonEnv.mpe[2].intsrc & nuonEnv.mpe[2].inten1) | (nuonEnv.mpe[3].intsrc & nuonEnv.mpe[3].inten1)) & INT_AUDIO) == 0)) {
-                    if (nuonEnv.TryPushAudioPeriod())
-                        last_time3 = new_time;
-                }
-            } else last_time3 = new_time;
-        }
-
-        nuonEnv.TriggerScheduledInterrupts();
-    }
+    EmulatorCore::RunUntilVideoFrame(frame_budget_us, /*push_audio=*/true);
 
     // Render video
     if (gl_initialized) {


### PR DESCRIPTION
Follow-up to #46. Started as the EmulatorCore dedupe toxie asked for; while issue #48 was open I bundled the Windows/MinGW build fixes onto the same branch because they touch the same files and the alternative would have been a stack of two-line PRs.

## Summary

**Frontend dedupe**

- New `src/EmulatorCore.{h,cpp}` owns the four `Init/LoadGame/ApplyController/RunUntilVideoFrame/Shutdown` entry points and the previously-duplicated globals (`nuonEnv`, `bQuit`, `bRun`, `g_ISOPath`, `g_ISOPrefix`).
- `NuanceMain_linux.cpp` and `libretro.cpp` shrink down to just frontend specifics (X11/SDL2 window vs. `retro_*` API). `libretro` now initialises CPU extensions / ALU lookup tables in the same order as the standalone build instead of splitting them between `retro_load_game` and `context_reset`.
- `NuonEnvironment::DrainAudioRing` becomes a public counterpart to `TryPushAudioPeriod` so libretro can pull host PCM frames synchronously in `retro_run` (the old libretro audio code was still using the pre-miniaudio `audio_buffer_offset` / `audio_buffer_played` fields and did not build).
- Drive-by build fix: `iso9660.h` was using Windows-only `SSIZE_T` outside its `_MSC_VER` block, which broke `archive.cpp` on Linux for both targets.

Libretro CI scaffolding (`.gitlab-ci.yml`, `dist/nuance_libretro.info`) was originally part of this PR but is now tracked separately in #62.

**Windows/MinGW build fixes (from issue #48)**

OM3GAZX walked the asmjit-enabled branch through a Windows build with MinGW GCC 16.1; each failure was a different flavour of the same Linux-shim-vs-real-MinGW-headers mismatch. All of the following are inert on Linux:

- `CMakeLists.txt` — only add `compat/` to the include path on non-Windows. On Windows the lowercase `compat/windows.h` shim was shadowing the real MinGW `<windows.h>` via NTFS case-insensitivity, breaking `archive.cpp` (`GetTickCount`, `CreateDirectoryA`, `SHFILEOPSTRUCTA`).
- `src/basetypes.h` — `<memory.h>` → `<cstring>`. MSVC's `<memory.h>` happens to drag in `memset`; MinGW's does not.
- `src/coff.cpp`, `src/file.cpp`, `src/nuonrom.cpp` — on Windows include `<share.h>` (and `<sys/stat.h>` in coff.cpp) for `_SH_DENYWR` / `_SH_DENYNO` / `_S_IREAD`. On Linux these were provided as macros by `linux_compat.h`, which `basetypes.h` only pulls in on `!_WIN32`.
- `src/MemoryManager.h` — replace `using namespace std;` with narrow `using std::vector; using std::string;`. The blanket using-directive was dragging `std::byte` (C++17, `<cstddef>`) into the global namespace of every TU that transitively included the header, which then collided with the `byte` typedef in `<rpcndr.h>` once `dinput.h -> objbase.h -> rpcndr.h` got parsed (MinGW GCC 16 is strict enough to flag this; MSVC and older GCC quietly let it through).

## Build

Standalone (Linux/X11):

```bash
mkdir build && cd build
cmake .. -DCMAKE_BUILD_TYPE=Release
make -j$(nproc)
# produces ./nuance
```

libretro core (32-bit or 64-bit, same flag):

```bash
mkdir build-libretro64 && cd build-libretro64
cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO=ON
make -j$(nproc)
# produces ./nuance_libretro.so - drop into ~/.config/retroarch/cores
```

Windows (MinGW64, GCC 16.1, confirmed by @OM3GAZX in issue #48): same CMake flow, the issue thread tracks the progressive build percentages as each shim mismatch was unblocked.

Both targets share `src/EmulatorCore.{h,cpp}` after this PR; the only frontend-specific files are `NuanceMain_linux.cpp` (X11/SDL2) and `libretro.cpp` (`retro_*` API).
