### PR TITLE
build: don't add compat/ include path on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,13 +145,22 @@ endif()
 
 target_include_directories(${NUANCE_TARGET} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/compat
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/external
     ${CMAKE_CURRENT_SOURCE_DIR}/external/glew-2.2.0/include
     ${CMAKE_CURRENT_SOURCE_DIR}/external/asmjit
     ${SDL2_INCLUDE_DIRS}
 )
+
+# compat/ contains Linux shims for Win32 headers (windows.h, dinput.h, etc.).
+# On Windows, NTFS is case-insensitive, so #include <windows.h> would resolve
+# to the lowercase compat/windows.h shim before the real MinGW SDK header and
+# break the build (see issue #48).
+if(NOT WIN32)
+    target_include_directories(${NUANCE_TARGET} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/compat
+    )
+endif()
 
 target_compile_definitions(${NUANCE_TARGET} PRIVATE
     GLEW_STATIC


### PR DESCRIPTION
Fixes #48.

`compat/` contains Linux shims for Win32 headers (`windows.h`, `dinput.h`, `tchar.h`, `Objbase.h`, etc.). NTFS is case-insensitive, so on a MinGW/G++ Windows build `#include <windows.h>` in `src/archive.cpp` resolves to the lowercase `compat/windows.h` shim before the real MinGW SDK header. The shim just pulls in `linux_compat.h`, which provides only a small subset of Win32 — enough for `MAX_PATH` (which is why line 121 doesn't error in the screenshot) but not `GetTickCount`, `CreateDirectoryA`, `SHFILEOPSTRUCTA`, `SHFileOperationA`, …

Fix: only add `compat/` to the include path on non-Windows builds.

Verified:
- Linux configure + build of the affected translation units still works (the pre-existing `SSIZE_T` issue in `iso9660.h` on non-MSVC is unrelated and tracked via #47).
- No effect on MSVC Windows builds (Nuance.vcxproj doesn't reference `compat/`).