### PR TITLE
Reset audio + MPE state when (re)loading a game (#53)

### DIFF
--- a/src/NuanceMain.cpp
+++ b/src/NuanceMain.cpp
@@ -484,6 +484,10 @@ bool Load(const char* file = nullptr)
     }
     const char* loadPath = resolved.c_str();
 
+    static bool s_loadedOnce = false;
+    if(s_loadedOnce)
+      nuonEnv.ResetForReload();
+
     bool bSuccess = nuonEnv.mpe[3].LoadNuonRomFile(loadPath);
     if(!bSuccess)
     {
@@ -501,6 +505,7 @@ bool Load(const char* file = nullptr)
     {
       nuonEnv.SetDVDBaseFromFileName(loadPath);
       nuonEnv.mpe[3].Go();
+      s_loadedOnce = true;
       UpdateControlPanelDisplay();
       SetWindowPos(display.hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
       Run();
@@ -916,9 +921,6 @@ INT_PTR CALLBACK ControlPanelDialogProc(HWND hwndDlg,UINT msg,WPARAM wParam,LPAR
           }
           else if((HWND)lParam == cbLoadFile)
           {
-            if (!load4firsttime)
-              nuonEnv.InitBios(); //!! hacky, but seems to work
-
             if (Load())
               load4firsttime = false;
 

--- a/src/NuanceMain_linux.cpp
+++ b/src/NuanceMain_linux.cpp
@@ -135,6 +135,10 @@ bool Load(const char* file)
     return false;
   }
 
+  static bool s_loadedOnce = false;
+  if (s_loadedOnce)
+    nuonEnv.ResetForReload();
+
   // Try loading as NUONROM-DISK/Bles first, then as raw COFF
   bool bSuccess = nuonEnv.mpe[3].LoadNuonRomFile(actualFile.c_str());
   if (!bSuccess) {
@@ -149,6 +153,7 @@ bool Load(const char* file)
   if (bSuccess) {
     nuonEnv.SetDVDBaseFromFileName(actualFile.c_str());
     nuonEnv.mpe[3].Go();
+    s_loadedOnce = true;
     Run();
     return true;
   }

--- a/src/NuonEnvironment.cpp
+++ b/src/NuonEnvironment.cpp
@@ -132,6 +132,38 @@ void NuonEnvironment::InitAudio()
   }
 }
 
+// Tear down audio + MPE state to "fresh boot" before loading a new game.
+// Without this, the second game inherits stale audio rate/mode/buffer
+// from the first; AudioSetSampleRate/ChannelMode short-circuit when the
+// new game requests the same values, the device is never re-init'd, and
+// pNuonAudioBuffer stays pointing at the previous game's memory — so the
+// new game runs silent (andkrau issue #53: Ballistic-as-2nd-game).
+void NuonEnvironment::ResetForReload()
+{
+  // Drop the audio device. The new game's BIOS calls will lazily
+  // re-create it from cleared rate/mode/buffer below.
+  CloseAudio();
+
+  // Mirror Init()'s audio-block defaults exactly.
+  pNuonAudioBuffer = nullptr;
+  oldNuonAudioChannelMode = nuonAudioChannelMode = 0;
+  nuonAudioPlaybackRate = 0;
+  nuonAudioBufferSize = 0;
+  audioInterruptCycleCount = cyclesPerAudioInterrupt;
+  whichAudioInterrupt = false;
+  audioMuted.store(false, std::memory_order_relaxed);
+
+  // Full MPE reset: clears registers, comm-bus state, JIT cache, intsrc.
+  for(uint32 i = 0; i < 4; i++)
+    mpe[i].Reset();
+  pendingCommRequests = 0;
+
+  // Re-install BIOS dispatch tables (the NuanceMain.cpp reload path
+  // already did this standalone as "hacky but seems to work" — now
+  // it's part of the reset).
+  InitBios();
+}
+
 void NuonEnvironment::CloseAudio()
 {
   if(audioDevice)

--- a/src/NuonEnvironment.h
+++ b/src/NuonEnvironment.h
@@ -99,6 +99,7 @@ public:
   }
 
   void Init();
+  void ResetForReload();
   ~NuonEnvironment();
 
   void WriteFile(MPE &mpe, uint32 fd, uint32 buf, uint32 len);


### PR DESCRIPTION
## Summary

Fixes #53 (Ballistic silent when loaded as the 2nd game).

Without this, loading a second game in the same session inherits stale `nuonAudioPlaybackRate` / `nuonAudioChannelMode` / `nuonAudioBufferSize` / `pNuonAudioBuffer` from the first game. The new game's `AudioSetSampleRate` / `AudioSetChannelMode` BIOS calls short-circuit when the requested values match the cached ones (`AudioSetChannelMode` explicitly returns early when only `WRAP_INT`/`HALF_INT` differ), so the miniaudio device is never re-initialised and `pNuonAudioBuffer` still points at the previous game's DMA buffer in memory — symptom: the new game plays silent.

## Change

- Add `NuonEnvironment::ResetForReload()` that:
  - calls `CloseAudio()` so the new game lazily re-creates the device
  - mirrors `Init()`'s audio-block defaults exactly (rate=0, buffer=0, mode=0, `pNuonAudioBuffer=nullptr`, mute=false, audio interrupt counter reset)
  - resets all 4 MPEs via `mpe[i].Reset()` (clears registers, comm-bus state, JIT cache, intsrc)
  - clears `pendingCommRequests`
  - re-installs the BIOS dispatch tables (`InitBios()`)
- Standalone Linux `Load()` (`NuanceMain_linux.cpp`) and Windows `Load()` (`NuanceMain.cpp`) call it on the 2nd-and-later entries via a static flag. Placing the call inside `Load()` covers all entry points: the load-file button, F2 dialog on Linux, and `WM_DROPFILES` drag-and-drop on Windows.
- Drop the existing standalone ``InitBios()`` call from the Windows `cbLoadFile` button handler — `ResetForReload()` now covers it (and the drag-drop path too).
- libretro is unaffected: `retro_load_game` already calls `nuonEnv.Init()` which is a full reset.

## Test plan

- [x] Linux 64-bit build (asmjit JIT) — clean build with the change applied
- [ ] Load Merlin Racing → exit → load Ballistic → confirm Ballistic has sound (the failure mode from #53)
- [ ] Load Ballistic first → confirm sound still works (unchanged path)
- [ ] Load Tempest 3000 → reload Tempest 3000 → confirm no regression
- [ ] Windows build — not tested locally, please verify on Win build

🤖 Generated with [Claude Code](https://claude.com/claude-code)