### PR TITLE
diag: NUANCE_FREEZE_DETECT env-knob to capture hung-MPE state (#17)

### DIFF
--- a/src/NuanceMain.cpp
+++ b/src/NuanceMain.cpp
@@ -1210,6 +1210,49 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
       if(nuonEnv.pendingCommRequests)
         DoCommBusController();
 
+      // NUANCE_FREEZE_DETECT=[<mpe>:]<sec> — when the selected MPE's pcexec
+      // stays inside a 256-byte window for <sec> wall-clock seconds, dump
+      // full state once. Catches hung-but-alive freezes like the T3K
+      // Level Select stall with JIT enabled (andkrau issue #17, where
+      // toxie's vector-test workaround flushes the JIT and unblocks it).
+      // Default MPE is 3 if only <sec> is given.
+      if((cycles % 2048) == 0)
+      {
+        static int fd_inited = 0;
+        static int fd_mpe = 3;
+        static int fd_sec = 0;
+        static uint32 fd_last_bucket = 0xFFFFFFFFu;
+        static uint64 fd_last_change_us = 0;
+        static bool fd_armed = true;
+        static uint64 fd_fires = 0;
+        if(!fd_inited) {
+          fd_inited = 1;
+          if(const char* s = getenv("NUANCE_FREEZE_DETECT")) {
+            const char* colon = strchr(s, ':');
+            if(colon) { fd_mpe = atoi(s) & 3; fd_sec = atoi(colon + 1); }
+            else      { fd_mpe = 3;           fd_sec = atoi(s); }
+          }
+        }
+        if(fd_sec > 0) {
+          const uint32 cur_bucket = nuonEnv.mpe[fd_mpe].pcexec & 0xFFFFFF00u;
+          const uint64 now = useconds_since_start();
+          if(cur_bucket != fd_last_bucket) {
+            fd_last_bucket = cur_bucket;
+            fd_last_change_us = now;
+            fd_armed = true;
+          } else if(fd_armed && fd_last_change_us > 0 &&
+                    (now - fd_last_change_us) > (uint64)fd_sec * 1000000ull) {
+            char reasonBuf[96];
+            fd_fires++;
+            sprintf_s(reasonBuf, sizeof(reasonBuf),
+                      "MPE%d PC stuck in 0x%08X.. for %ds (fire #%llu)",
+                      fd_mpe, cur_bucket, fd_sec, (unsigned long long)fd_fires);
+            nuonEnv.mpe[fd_mpe].DumpFreezeState(stderr, reasonBuf);
+            fd_armed = false;
+          }
+        }
+      }
+
       // handle the sysTimer0, sysTimer1 and vidTimer (video refresh at 50/60Hz)
       // note that these all run at the real hostCPU time rate, NOT the actual emulated time/cycles!
       if ((cycles % 500) == 0) // only pull hostCPU timer from time to time, otherwise too costly

--- a/src/NuanceMain_linux.cpp
+++ b/src/NuanceMain_linux.cpp
@@ -205,6 +205,50 @@ int main(int argc, char* argv[])
       if (nuonEnv.pendingCommRequests)
         DoCommBusController();
 
+      // NUANCE_FREEZE_DETECT=[<mpe>:]<sec> — when the selected MPE's pcexec
+      // stays inside a 256-byte window for <sec> wall-clock seconds, dump
+      // full state once. Catches hung-but-alive freezes like the T3K
+      // Level Select stall with JIT enabled (andkrau issue #17, where
+      // toxie's vector-test workaround flushes the JIT and unblocks it).
+      // Default MPE is 3 if only <sec> is given.
+      if ((cycles % 2048) == 0)
+      {
+        static int fd_inited = 0;
+        static int fd_mpe = 3;
+        static int fd_sec = 0;
+        static uint32 fd_last_bucket = 0xFFFFFFFFu;
+        static uint64 fd_last_change_us = 0;
+        static bool fd_armed = true;
+        static uint64 fd_fires = 0;
+        if (!fd_inited) {
+          fd_inited = 1;
+          if (const char* s = getenv("NUANCE_FREEZE_DETECT")) {
+            const char* colon = strchr(s, ':');
+            if (colon) { fd_mpe = atoi(s) & 3; fd_sec = atoi(colon + 1); }
+            else       { fd_mpe = 3;           fd_sec = atoi(s); }
+          }
+        }
+        if (fd_sec > 0) {
+          const uint32 cur_bucket = nuonEnv.mpe[fd_mpe].pcexec & 0xFFFFFF00u;
+          const uint64 now = useconds_since_start();
+          if (cur_bucket != fd_last_bucket) {
+            // PC moved to a new 256B window — reset timer, re-arm if previously fired.
+            fd_last_bucket = cur_bucket;
+            fd_last_change_us = now;
+            fd_armed = true;
+          } else if (fd_armed && fd_last_change_us > 0 &&
+                     (now - fd_last_change_us) > (uint64)fd_sec * 1000000ull) {
+            char reasonBuf[96];
+            fd_fires++;
+            snprintf(reasonBuf, sizeof(reasonBuf),
+                     "MPE%d PC stuck in 0x%08X.. for %ds (fire #%llu)",
+                     fd_mpe, cur_bucket, fd_sec, (unsigned long long)fd_fires);
+            nuonEnv.mpe[fd_mpe].DumpFreezeState(stderr, reasonBuf);
+            fd_armed = false; // don't spam this exact window — wait for PC to leave
+          }
+        }
+      }
+
       if ((cycles % 500) == 0)
       {
         static uint64 last_time0 = useconds_since_start();

--- a/src/mpe.cpp
+++ b/src/mpe.cpp
@@ -2380,3 +2380,56 @@ void MPE::ExecuteSingleStep()
   nativeCodeCache.FlushRegion(pcexec, pcexec);
   FetchDecodeExecute();
 }
+
+// Dump everything useful for diagnosing a hung MPE: pcexec + register file,
+// stack contents, disasm of 16 packets around pcexec, and JIT-cache stats.
+// Triggered from NUANCE_FREEZE_DETECT (see the main loops) but safe to call
+// from anywhere — pure read of MPE/memory state.
+void MPE::DumpFreezeState(FILE* out, const char* reason)
+{
+  if(!out) out = stderr;
+  fprintf(out, "\n[FREEZE-DETECT mpe%u] %s\n", mpeIndex, reason ? reason : "stuck");
+  fprintf(out, "  pc=0x%08X rz=0x%08X sp=0x%08X cc=0x%08X\n",
+          pcexec, rz, regs[31], cc);
+  fprintf(out, "  rzi1=0x%08X rzi2=0x%08X intvec1=0x%08X intvec2=0x%08X\n",
+          rzi1, rzi2, intvec1, intvec2);
+  fprintf(out, "  mpectl=0x%08X intsrc=0x%08X intctl=0x%08X inten1=0x%08X inten2sel=0x%08X\n",
+          mpectl, intsrc, intctl, inten1, inten2sel);
+  fprintf(out, "  commctl=0x%08X commxmit0=0x%08X comminfo=0x%08X\n",
+          commctl, commxmit[0], comminfo);
+  fprintf(out, "  regs:\n");
+  for(int i = 0; i < 32; i += 4)
+    fprintf(out, "    r%-2d: %08X %08X %08X %08X\n",
+            i, regs[i], regs[i+1], regs[i+2], regs[i+3]);
+
+  // 64 bytes of stack starting at SP.
+  fprintf(out, "  stack@sp(0x%08X):", regs[31]);
+  for(uint32 off = 0; off < 64; off += 4) {
+    uint32* p = (uint32*)nuonEnv.GetPointerToMemory(mpeIndex, regs[31] + off, false);
+    fprintf(out, " %08X", p ? SwapBytes(*p) : 0xDEADDEAD);
+  }
+  fprintf(out, "\n");
+
+  // 16 packets around pcexec (8 before, 8 from pcexec onwards). The "before"
+  // disasm walks forward from pcexec-64 so packet boundaries may be off if
+  // there's variable-length code earlier, but the "from pcexec" half is
+  // always accurate.
+  fprintf(out, "  disasm around pc:\n");
+  uint32 dPc = (pcexec >= 64) ? (pcexec - 64) : 0;
+  for(int i = 0; i < 16; i++) {
+    char buf[256] = {};
+    PrintInstructionCachePacket(buf, sizeof(buf), dPc);
+    fprintf(out, "    %s%08X: %s", (dPc == pcexec) ? "->" : "  ", dPc, buf);
+    if(buf[0] && buf[strlen(buf)-1] != '\n') fputc('\n', out);
+    uint8* mp = (uint8*)nuonEnv.GetPointerToMemory(mpeIndex, dPc, false);
+    if(!mp) break;
+    uint32 delta = GetPacketDelta(mp, 1);
+    if(delta == 0 || delta > 64) delta = 2;
+    dPc += delta;
+  }
+
+  fprintf(out, "  JIT: numNativeCodeCacheFlushes=%u numNonCompilablePackets=%u overlays=%u\n",
+          numNativeCodeCacheFlushes, numNonCompilablePackets,
+          overlayManager.GetOverlaysInUse());
+  fflush(out);
+}

--- a/src/mpe.h
+++ b/src/mpe.h
@@ -409,6 +409,7 @@ public:
   void ScheduleInstructionQuartet(InstructionCacheEntry &destEntry, const uint32 baseSlot, const InstructionCacheEntry &srcEntry);
   bool FetchDecodeExecute();
   void ExecuteSingleStep();
+  void DumpFreezeState(FILE* out, const char* reason);
 
   void ExecuteNuances(const InstructionCacheEntry& entry)
   {


### PR DESCRIPTION
## Summary

Tooling to help diagnose freezes like the remaining T3K Level Select stall in #17 (only when JIT is enabled; toxie's "Options → Vector Test once" workaround flushes the JIT cache and unblocks it).

Without this, the only way to see *what* the MPE is spinning on is to rebuild with print-sprinkles. With this you can run:

\`\`\`
NUANCE_FREEZE_DETECT=3:5 ./nuance "Tempest 3000 (USA, Europe).iso"
\`\`\`

then navigate to Level Select normally. When MPE3 has been stuck in a 256-byte PC window for 5 seconds, the run loop emits a single \`[FREEZE-DETECT mpe3]\` block with:

- pcexec, rz, sp, cc, intvec1/2, intsrc/intctl/inten*
- mpectl, commctl, commxmit0, comminfo
- all 32 scalar registers
- 64 bytes of stack at SP
- 16 packets of disasm around pcexec (anchored on pcexec, ±~64 bytes)
- JIT-cache stats (flush count, non-compilable, overlays-in-use)

The detector re-arms when the PC leaves the 256-byte window, so subsequent freezes also dump (with a fire counter in the header).

## Format

\`NUANCE_FREEZE_DETECT=[<mpe>:]<sec>\` — \`<mpe>\` defaults to 3 (game CPU). The check is sampled at \`cycles % 2048 == 0\` so it has negligible cost when the env var is unset (one branch on a cached static).

## Change

- Added \`MPE::DumpFreezeState(FILE* out, const char* reason)\` — pure read of MPE state + memory; cross-platform.
- Run loop in both \`NuanceMain.cpp\` (Windows) and \`NuanceMain_linux.cpp\` wires the env-var, tracks the 256-byte PC bucket, and fires the dump.

## Test plan

- [x] Linux 64-bit build — clean
- [x] Smoke test on Ballistic (well-behaved game) — no \`FREEZE-DETECT\` lines emitted, as expected
- [ ] Capture the T3K Level Select freeze with JIT enabled — *please run this on Windows with your test harness*; I cannot reach Level Select from a non-interactive shell here
- [ ] Confirm re-arm: after Vector Test workaround unblocks the level-select, the dump fires again on the next freeze (or not, if the game stays unstuck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)