### PR TITLE
Clear back buffer before first VidConfig (#29)

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -400,7 +400,25 @@ void IncrementVideoFieldCounter()
 void RenderVideo(const int winwidth, const int winheight)
 {
   if(!bCanDisplayVideo)
+  {
+    // No game frame yet — clear the back buffer to black and present so
+    // we don't display whatever uninitialised contents the GL driver left
+    // behind. In windowed mode the OS draws the desktop around the
+    // hbrBackground=NULL window so the undefined contents are invisible;
+    // in fullscreen they cover the screen as green/garbage (issue #29:
+    // "Command line not working" — command-line load triggers auto-
+    // fullscreen before the game has called VidConfig, so RenderVideo
+    // used to bail out without ever clearing+swapping).
+    if(bUseSeparateThread) gfx_lock.lock();
+    glViewport(0, 0, winwidth, winheight);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+#ifdef _WIN32
+    SwapBuffers(display.hDC);
+#endif
+    if(bUseSeparateThread) gfx_lock.unlock();
     return;
+  }
 
   if(!bTexturesInitialized)
   {


### PR DESCRIPTION
## Summary

Fixes #29 (\"Command line not working\" — green/garbage screen when loading via command line or drag-and-drop, audio works fine).

### Root cause

When a game is loaded via the command line, \`NuanceMain.cpp\` toggles fullscreen immediately after \`Load()\` returns (the \`load4firsttime\` auto-fullscreen path introduced in 07cd484). At that point the game has set \`bRun=true\` but hasn't yet called \`VidConfig\` (so \`bCanDisplayVideo\` is still false), and the early-return in \`RenderVideo\` exits without ever clearing or swapping the back buffer.

- In **windowed mode** the OS draws the desktop around the window (the class has \`hbrBackground=NULL\`), so the uninitialised back-buffer contents are not visible.
- In **fullscreen** the window covers the screen and whatever the GL driver left in the back buffer (often a flat green on Intel iGPU) gets presented.

Audio works because the game IS running — only the visuals stay garbage until the first \`VidConfig\`. Some games never auto-progress past their launcher in our emulator and so the green/garbage screen persists forever.

The drag-and-drop path doesn't auto-fullscreen, but if the user manually presses F1 before the first frame, the same garbage is presented in fullscreen.

### Fix

On the early-return path of \`RenderVideo\` (when \`!bCanDisplayVideo\`):

- Set the viewport for the current window size
- \`glClearColor\` to black + \`glClear(GL_COLOR_BUFFER_BIT)\`
- On Windows, \`SwapBuffers\` so the back buffer is presented (Linux callers swap after \`RenderVideo\` returns, so they only need the clear). The \`#ifdef _WIN32\` mirrors the existing swap pattern at the end of \`RenderVideo\`.

Net behaviour: the window now shows black instead of green/garbage from the moment the game is loaded until \`VidConfig\` fires.

## Test plan

- [x] Linux 64-bit build (asmjit JIT) — clean
- [ ] Windows: load Ballistic from command line — should show black (then game graphics) instead of green
- [ ] Windows: drag-drop \`.iso\` onto Nuance window — should not show green even if fullscreen toggled before VidConfig
- [ ] Existing button-load path (file dialog) — unchanged behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)