### PR TITLE
jit: add missing asmjit branches to MOVQMR / MOVQRM / MOVSSMR / UNPCKLRR / MOVLHRR (fix #57)

### DIFF
--- a/src/nativecodecache.cpp
+++ b/src/nativecodecache.cpp
@@ -3766,6 +3766,15 @@ void NativeCodeCache::X86Emit_MOVQRR(const x86Reg regDest, const x86Reg regSrc)
 
 void NativeCodeCache::X86Emit_MOVQMR(const x86Reg regDest, const uintptr_t base, const x86IndexReg index, const x86ScaleVal scale, const int32 disp)
 {
+  #ifdef USE_ASMJIT
+  if (asmjitAs) {
+    auto& a = *asmjitAs;
+    auto m = NuanceJit::buildMem(a, base, index, scale, disp, 8);
+    a.movq(NuanceJit::toXmm(regDest), m);
+    return;
+  }
+  #endif
+
   if(regDest < x86Reg::x86Reg_xmm0)
   {
     //MMX
@@ -3822,6 +3831,15 @@ void NativeCodeCache::X86Emit_MOVDQAMR(const x86Reg regDest, const uintptr_t bas
 
 void NativeCodeCache::X86Emit_MOVQRM(const x86Reg regSrc, const uintptr_t base, const x86IndexReg index, const x86ScaleVal scale, const int32 disp)
 {
+  #ifdef USE_ASMJIT
+  if (asmjitAs) {
+    auto& a = *asmjitAs;
+    auto m = NuanceJit::buildMem(a, base, index, scale, disp, 8);
+    a.movq(m, NuanceJit::toXmm(regSrc));
+    return;
+  }
+  #endif
+
   if(regSrc < x86Reg::x86Reg_xmm0)
   {
     //MMX
@@ -4393,6 +4411,15 @@ void NativeCodeCache::X86Emit_MOVDRR2(const x86Reg regDest, const x86Reg regSrc)
 
 void NativeCodeCache::X86Emit_MOVSSMR(const x86Reg regDest, const uintptr_t base, const x86IndexReg index, const x86ScaleVal scale, const int32 disp)
 {
+  #ifdef USE_ASMJIT
+  if (asmjitAs) {
+    auto& a = *asmjitAs;
+    auto m = NuanceJit::buildMem(a, base, index, scale, disp, 4);
+    a.movss(NuanceJit::toXmm(regDest), m);
+    return;
+  }
+  #endif
+
   //SSE
   *pEmitLoc++ = 0xF3;
   *pEmitLoc++ = 0x0F;
@@ -4422,6 +4449,14 @@ void NativeCodeCache::X86Emit_MOVDRM(const x86Reg regSrc, const uintptr_t base, 
 
 void NativeCodeCache::X86Emit_UNPCKLRR(const x86Reg regDest, const x86Reg regSrc)
 {
+  #ifdef USE_ASMJIT
+  if (asmjitAs) {
+    auto& a = *asmjitAs;
+    a.unpcklps(NuanceJit::toXmm(regDest), NuanceJit::toXmm(regSrc));
+    return;
+  }
+  #endif
+
   //SSE
   *pEmitLoc++ = 0x0F;
   *pEmitLoc++ = 0x14;
@@ -4436,6 +4471,14 @@ void NativeCodeCache::X86Emit_UNPCKLRR(const x86Reg regDest, const x86Reg regSrc
 
 void NativeCodeCache::X86Emit_MOVLHRR(const x86Reg regDest, const x86Reg regSrc)
 {
+  #ifdef USE_ASMJIT
+  if (asmjitAs) {
+    auto& a = *asmjitAs;
+    a.movlhps(NuanceJit::toXmm(regDest), NuanceJit::toXmm(regSrc));
+    return;
+  }
+  #endif
+
   //SSE
   *pEmitLoc++ = 0x0F;
   *pEmitLoc++ = 0x16;


### PR DESCRIPTION
Fixes #57.

The new SSSE3 fast paths added in f352cff (`EmitMEM.cpp`) call five emit helpers that, in upstream master, only had the legacy x86 byte-emit path - no `#ifdef USE_ASMJIT if (asmjitAs)` branch:

  - `X86Emit_MOVQMR` — load 8 bytes from memory to XMM
  - `X86Emit_MOVQRM` — store low 8 bytes of XMM to memory
  - `X86Emit_MOVSSMR` — load 4 bytes from memory to XMM
  - `X86Emit_UNPCKLRR` — unpcklps
  - `X86Emit_MOVLHRR` — movlhps

On 64-bit `USE_ASMJIT` builds the asmjit code stream for blocks that hit these new SSSE3 paths is therefore **missing the corresponding instructions entirely**. The legacy bytes still get written into `pEmitLoc`, but `pEmitLoc` is dead in the asmjit build (the dispatcher executes asmjit's output, not the byte buffer). Result: PSHUFB / MOVDQU / MOVD store paths that should load from a scalar reg or `srcAddress` into XMM are silently no-ops, XMM contains garbage from the previous block, and the subsequent permute+store corrupts MPE state. Eventually a corrupted PC-equivalent points control flow to a NUON-side address (the `0x400026b0` PC in issue #57's gdb dump) and SIGSEGV.

Win32 / 32-bit builds are unaffected because they go through the legacy byte path end-to-end - the missing-asmjit-branch is invisible there.

### The fix

Add the asmjit branch to each of the five helpers, mirroring the existing pattern in the surrounding emit helpers (`MOVDQUMR` / `MOVDQURM` / `MOVDRM` / `SHUFIR` / `PSHUFBRR`):

```cpp
MOVQMR    -> a.movq(xmm, buildMem(8))
MOVQRM    -> a.movq(buildMem(8), xmm)
MOVSSMR   -> a.movss(xmm, buildMem(4))
UNPCKLRR  -> a.unpcklps(xmm, xmm)
MOVLHRR   -> a.movlhps(xmm, xmm)
```

Legacy byte paths are left intact for the 32-bit / non-asmjit build. The f352cff commit itself is unchanged - this just supplies the asmjit code emit that its new SSSE3 paths assumed already existed.

### Verification

Linux x86_64, Mesa Intel HD 615, JIT enabled, stock `nuance.cfg`:

| game | upstream master `bfac546` | this PR |
| --- | --- | --- |
| Ballistic | SIGSEGV at ~5-12s, 3/3 runs | alive after 20s, 3/3 runs ✅ |
| Merlin Racing | SIGSEGV at ~5-12s | alive after 20s ✅ |

`Kc/s` on Ballistic title screen settles at ~3-4k after the fix (compared to the pre-fix ~9.5k peak that was inflated because the JIT was actually skipping work, leading to the crash). The JIT is now doing all the work the SSSE3 paths intended.

Audit script that found the missing branches, in case you want to confirm coverage:

```bash
awk '
  /^void NativeCodeCache::X86Emit_[A-Z]+\(/ {
    if (fn) print fn, (has_asmjit ? "OK" : "MISSING")
    match($0, /X86Emit_[A-Z0-9_]+/); fn = substr($0, RSTART, RLENGTH)
    brace = 0; has_asmjit = 0
  }
  /\{/ && fn { brace += gsub(/\{/, "{") }
  /\}/ && fn { brace -= gsub(/\}/, "}"); if (brace == 0) { print fn, (has_asmjit ? "OK" : "MISSING"); fn = "" } }
  /USE_ASMJIT/ && fn { has_asmjit = 1 }
' src/nativecodecache.cpp | grep -E "MOVQ|MOVSS|UNPCK|MOVLH" | grep MISSING
```

Should print nothing after this PR (it printed five lines before).

`X86Emit_MOVQRR` (xmm-to-xmm 8-byte move) also has no asmjit branch but isn't called from any active emit path - left untouched here. Happy to add it as a defensive follow-up if you'd like.
