### PR TITLE
Fix Linux clean build (libretro audio ring + glew + standalone checkbox)

### DIFF
--- a/external/glew.c
+++ b/external/glew.c
@@ -17964,7 +17964,7 @@ GLboolean GLEWAPIENTRY glewGetExtension (const char* name)
 typedef const GLubyte* (GLAPIENTRY * PFNGLGETSTRINGPROC) (GLenum name);
 typedef void (GLAPIENTRY * PFNGLGETINTEGERVPROC) (GLenum pname, GLint *params);
 
-static GLenum GLEWAPIENTRY glewContextInit ()
+GLenum GLEWAPIENTRY glewContextInit ()
 {
   PFNGLGETSTRINGPROC getString;
   const GLubyte* s;

--- a/src/NuanceUI.cpp
+++ b/src/NuanceUI.cpp
@@ -544,7 +544,10 @@ static void DrawSettingsPanel()
     ImGui::Checkbox("DumpCompiledBlocks", &nuonEnv.compilerOptions.bDumpBlocks);
     ImGui::SameLine();
     ImGui::TextDisabled("(verbose; for debugging)");
-    ImGui::Checkbox("MPE3PacketHack", &nuonEnv.compilerOptions.bMPE3PacketHack);
+    // bMPE3PacketHack is a char (0/1/2); bridge through a bool for the checkbox.
+    { bool mpe3hack = nuonEnv.compilerOptions.bMPE3PacketHack != 0;
+      if(ImGui::Checkbox("MPE3PacketHack", &mpe3hack))
+        nuonEnv.compilerOptions.bMPE3PacketHack = mpe3hack ? 1 : 0; }
     ImGui::SameLine();
     ImGui::TextDisabled("(most likely only relevant for Tempest 3000)");
 

--- a/src/NuonEnvironment.cpp
+++ b/src/NuonEnvironment.cpp
@@ -257,6 +257,31 @@ bool NuonEnvironment::TryPushAudioPeriod()
   return true;
 }
 
+uint32 NuonEnvironment::DrainAudioRing(int16_t* dst, uint32 maxFrames)
+{
+  if(!audioRing || audioRingSize == 0 || maxFrames == 0)
+    return 0;
+
+  const uint32 w = audioRingWritePos.load(std::memory_order_acquire);
+  const uint32 r = audioRingReadPos.load(std::memory_order_relaxed);
+  uint32 available = w - r; // bytes
+  const uint32 maxBytes = maxFrames * 4; // 2ch * 2B per frame
+  if(available > maxBytes) available = maxBytes;
+  const uint32 toCopy = available - (available % 4); // align to whole frame
+  if(toCopy == 0)
+    return 0;
+
+  for(uint32 i = 0; i < toCopy / 2; i++)
+  {
+    const uint32 byteIdx = (r + i*2) % audioRingSize;
+    const uint8 hi = audioRing[byteIdx];
+    const uint8 lo = audioRing[(byteIdx + 1) % audioRingSize];
+    dst[i] = (int16_t)(lo | (hi << 8));
+  }
+  audioRingReadPos.store(r + toCopy, std::memory_order_release);
+  return toCopy / 4;
+}
+
 void *NuonEnvironment::GetPointerToMemory(const uint32 mpe_idx, const uint32 address, const bool bCheckAddress)
 {
   if(address < MPE_ADDR_SPACE_BASE)

--- a/src/NuonEnvironment.h
+++ b/src/NuonEnvironment.h
@@ -121,6 +121,12 @@ public:
   // try again on the next loop iteration
   bool TryPushAudioPeriod();
 
+  // Drain up to maxFrames stereo frames from the host audio ring into dst
+  // (already little-endian int16 interleaved L/R). Returns the number of frames
+  // written. Used by the libretro core's audio_batch_cb path; the standalone
+  // build consumes the same ring from its miniaudio callback.
+  uint32 DrainAudioRing(int16_t* dst, uint32 maxFrames);
+
   bool IsAudioHalfInterruptEnabled() const
   {
     return (nuonAudioChannelMode & ENABLE_HALF_INT);

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -505,20 +505,12 @@ void retro_run(void)
         video_cb(framebuffer, FB_WIDTH, FB_HEIGHT, FB_WIDTH * 4);
     }
 
-    // Audio
-    if (nuonEnv.pNuonAudioBuffer && nuonEnv.nuonAudioBufferSize > 0) {
-        uint32 halfSize = nuonEnv.nuonAudioBufferSize >> 1;
-        uint32 frames = halfSize / 4; // 16-bit stereo = 4 bytes per frame
-        if (frames > AUDIO_BUFFER_SIZE / 2) frames = AUDIO_BUFFER_SIZE / 2;
-
-        const uint8* src = nuonEnv.pNuonAudioBuffer + nuonEnv.audio_buffer_offset;
-        // Byteswap from big-endian NUON to little-endian
-        for (uint32 i = 0; i < frames * 2; i++) {
-            audio_buffer[i] = (int16_t)((src[i*2+1]) | (src[i*2] << 8));
-        }
+    // Audio: drain the host audio ring (byte-swapped to LE inside DrainAudioRing).
+    // Replaces the old pNuonAudioBuffer/audio_buffer_offset path which no longer
+    // exists after the audio-ring refactor (NuonEnvironment::DrainAudioRing).
+    uint32 frames = nuonEnv.DrainAudioRing(audio_buffer, AUDIO_BUFFER_SIZE / 2);
+    if (frames)
         audio_batch_cb(audio_buffer, frames);
-        _InterlockedExchange(&nuonEnv.audio_buffer_played, 1);
-    }
 }
 
 size_t retro_serialize_size(void) { return 0; }


### PR DESCRIPTION
## Summary

A clean checkout currently fails to build on Linux/GCC in several independent ways. This fixes all of them, for both the libretro core and the standalone build:

- **glew (both builds):** the bundled `external/glew.c` defines `glewContextInit()` as `static`, but `glew-2.3.1`'s `glew.h` declares it non-static (`GLEWAPI`), so a clean build fails with *"static declaration follows non-static declaration"*. The cores only ever built incrementally with a stale glew object. Dropping `static` matches the header.
- **Audio (libretro):** `libretro.cpp` still called the removed `pNuonAudioBuffer` / `audio_buffer_offset` / `audio_buffer_played` API, and after the audio-ring refactor the ring had no public consumer. Adds `NuonEnvironment::DrainAudioRing(int16_t*, uint32)` (drains LE stereo frames, advances the read cursor — same ring the standalone miniaudio callback uses) and ports the libretro audio path to it.
- **MPE3PacketHack checkbox (standalone):** `bMPE3PacketHack` is a `char` (0/1/2) but `ImGui::Checkbox` takes a `bool*`, so `NuanceUI.cpp` failed with *"cannot convert char* to bool*"*. Bridged through a temporary bool.

Verified: clean `-DBUILD_LIBRETRO=ON` and `-DBUILD_LIBRETRO=OFF` builds both succeed on x86_64/GCC.