### PR TITLE
CMakeLists: don't link SDL2 into the libretro core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,11 @@ target_link_libraries(${NUANCE_TARGET} PRIVATE
     #murmurhash # unused - see add_library above
     $<$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>:asmjit_static>
     OpenGL::GL
-    ${SDL2_LIBRARIES}
+    # SDL2 is a standalone-only dependency (windowing + audio); the libretro core
+    # uses neither. Guarding it out also avoids a CMP0004 hard error when the
+    # libretro build infra passes SDL2_LIBRARIES as a raw `sdl2-config --libs`
+    # string (e.g. "-L/usr/lib/... -lSDL2 ") that has trailing whitespace.
+    $<$<NOT:$<BOOL:${BUILD_LIBRETRO}>>:${SDL2_LIBRARIES}>
     $<$<NOT:$<PLATFORM_ID:Windows>>:pthread>
     $<$<NOT:$<PLATFORM_ID:Windows>>:dl>
     $<$<NOT:$<PLATFORM_ID:Windows>>:m>


### PR DESCRIPTION
The libretro mirror build (git.libretro.com pipeline #80565) fails at the CMake generate step on current master:

```
CMake Error at CMakeLists.txt:164 (add_library):
  Target "nuance_libretro" links to item "-L/usr/lib/x86_64-linux-gnu -lSDL2
  " which has leading or trailing whitespace.  This is now an error according
  to policy CMP0004.
```

The libretro core uses neither SDL2 windowing nor SDL2 audio, but `${SDL2_LIBRARIES}` was in `target_link_libraries` unconditionally. The libretro build infra passes `SDL2_LIBRARIES` as a raw `sdl2-config --libs` string with a trailing space (`-L/usr/lib/... -lSDL2 `), which CMP0004 rejects as a link item with trailing whitespace — killing the build before any compilation.

Guarding the SDL2 link behind `$<$<NOT:$<BOOL:${BUILD_LIBRETRO}>>:...>` lets the core configure cleanly. The standalone build (which gets `SDL2_LIBRARIES` from `find_package`) is unaffected: verified that both `-DBUILD_LIBRETRO=ON` (with the whitespace string) and the default standalone configure now reach "Generating done".