### PR TITLE
libretro: rebuild GL resources on context_reset (fixes black screen)

### DIFF
--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -155,6 +155,14 @@ static void context_reset(void)
 
     gl_initialized = true;
 
+    // The GL context was just (re)created. RetroArch can call context_reset more
+    // than once per session (e.g. it tears down and rebuilds the GL context on a
+    // windowed->fullscreen switch, which happens when its primary video driver is
+    // Vulkan). All GL object names from the previous context are now dead, so tell
+    // the video module to rebuild its textures/shaders; otherwise it keeps the
+    // one-time-init guards set and renders with stale handles -> black screen.
+    VideoInvalidateGLState();
+
     // Init CPU extensions and lookup tables (deferred from retro_load_game)
     static bool tables_initialized = false;
     if (!tables_initialized) {
@@ -180,6 +188,9 @@ static void context_reset(void)
 static void context_destroy(void)
 {
     gl_initialized = false;
+    // GL objects die with the context; make sure they are rebuilt after the next
+    // context_reset rather than reused with stale handles.
+    VideoInvalidateGLState();
 }
 
 // --- Libretro API ---

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -398,6 +398,24 @@ void IncrementVideoFieldCounter()
   }
 }
 
+void VideoInvalidateGLState()
+{
+  // The GL context was (re)created, so every GL object name created by the
+  // previous context (textures in InitTextures, the YCrCbA->RGB shader, etc.)
+  // is now invalid. Clear the lazy-init guards so RenderVideo regenerates them
+  // against the new context on the next frame; otherwise we would keep drawing
+  // with dead handles and present a black screen.
+  bTexturesInitialized = false;
+  bShadersInstalled = false;
+  bSetupViewport = false;
+  // The freshly generated mainTexName/osdTexName have no storage until
+  // glTexImage2D runs. Force the glTexImage2D upload path (rather than
+  // glTexSubImage2D, which is a no-op on a texture without storage and would
+  // leave the shader sampling all-zero) by resetting the cached pixel types.
+  bMainTexturePixType = -1;
+  bOverlayTexturePixType = -1;
+}
+
 void RenderVideo(const int winwidth, const int winheight)
 {
   if(!bCanDisplayVideo)

--- a/src/video.h
+++ b/src/video.h
@@ -108,4 +108,11 @@ void RenderVideo(int width, int height);
 void VideoCleanup();
 void IncrementVideoFieldCounter();
 
+// Invalidate the lazily-created GL resources (textures, shaders, viewport) so
+// they get rebuilt on the next RenderVideo. Must be called whenever the GL
+// context is (re)created, because all GL object names from the previous context
+// are then dead. RetroArch destroys/recreates the context e.g. on a
+// windowed->fullscreen switch, which is common when its primary driver is Vulkan.
+void VideoInvalidateGLState();
+
 #endif


### PR DESCRIPTION
## Summary

A user reported a black screen running the libretro core in RetroArch 1.22.2 on Linux (NVIDIA, X11), while emulation ran normally. Root cause: the video module creates its GL textures and the YCrCbA->RGB shader lazily once, guarded by static `bTexturesInitialized` / `bShadersInstalled` / `bSetupViewport` flags, and never rebuilds them.

RetroArch can call `context_reset` more than once per session, destroying and recreating the GL context in between — e.g. on the windowed->fullscreen switch at startup, which is common when its primary video driver is Vulkan (the reporting log shows two `context_reset` calls). After the second context, all GL object names from the first are dead, `RenderVideo` skips `InitTextures` because the guard is still set, and the core draws with stale handles, producing a black screen.

Fix: add `VideoInvalidateGLState()`, which clears those guards (and resets the cached texture pixel types so the regenerated textures get real `glTexImage2D` storage instead of being sampled empty), and call it from `context_reset` and `context_destroy` so textures/shaders are rebuilt against the new context on the next frame.

Compile-tested; runtime confirmation by the reporter is pending.