### PR TITLE
libretro: embed GLSL shaders with on-disk fallback (fixes black screen)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,14 @@ else()
     set(NUANCE_TARGET nuance)
 endif()
 
+# The GLSL shaders are embedded into the binary via src/embedded_shaders.h,
+# which #includes the real .vs/.fs files as C++ raw strings (they carry their
+# own #ifdef EMBED_HLSL guards, so the files stay valid standalone GLSL too).
+# No generated header: the .vs/.fs files are the single source of truth.
+# ShaderProgram still loads external shader files first and only falls back to
+# the embedded copy when none are found next to the binary. The repo root is on
+# the include path below so the #include "video_*.vs/.fs" lines resolve.
+
 target_include_directories(${NUANCE_TARGET} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/ShaderProgram.cpp
+++ b/src/ShaderProgram.cpp
@@ -1,6 +1,8 @@
 #include <string>
 #include <cstdio>
+#include <cstring>
 #include "ShaderProgram.h"
+#include "embedded_shaders.h"
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -97,16 +99,49 @@ bool ShaderProgram::InstallShaderSourceFromFile(const char * const filename, GLe
     err = fopen_s(&inFile,(tmps + filename).c_str(),"rb");
   }
 
+  GLchar *buffer = nullptr;
+  GLint length = 0;
+
   if(err == 0)
   {
     fseek(inFile,0,SEEK_END);
-    const GLint length = ftell(inFile);
+    length = ftell(inFile);
 
-    GLchar *buffer = new GLchar[length+1];
-    const GLchar **pBuffer = (const GLchar **)(&buffer);
+    buffer = new GLchar[length+1];
     buffer[length] = '\0';
     fseek(inFile,0,SEEK_SET);
     fread(buffer,sizeof(char),length,inFile);
+    fclose(inFile);
+  }
+  else
+  {
+    // No shader file on disk (e.g. the libretro core has no .vs/.fs files next
+    // to it - GetModuleFileName resolves to the RetroArch binary, not the core).
+    // Fall back to the source compiled into the binary so rendering still works.
+    const char * const embedded = GetEmbeddedShaderSource(filename);
+    if(embedded)
+    {
+      // The embedded source is the .vs/.fs file turned into a C++ raw string.
+      // Because the raw string opens right after the file's leading
+      // "#ifdef EMBED_HLSL", it captures that guard's closing "#endif" at the
+      // start and the trailing "#ifdef EMBED_HLSL" at the end. Wrap the whole
+      // thing in "#if 1 ... #endif" so those stray directives stay balanced for
+      // the GLSL preprocessor: the leading #endif closes our #if 1, and the
+      // trailing #ifdef is closed by our appended #endif.
+      static const char prefix[] = "#if 1\n";
+      static const char suffix[] = "\n#endif\n";
+      const size_t embLen = strlen(embedded);
+      length = (GLint)(sizeof(prefix)-1 + embLen + sizeof(suffix)-1);
+      buffer = new GLchar[length+1];
+      memcpy(buffer, prefix, sizeof(prefix)-1);
+      memcpy(buffer + sizeof(prefix)-1, embedded, embLen);
+      memcpy(buffer + sizeof(prefix)-1 + embLen, suffix, sizeof(suffix)); // incl. '\0'
+    }
+  }
+
+  if(buffer)
+  {
+    const GLchar **pBuffer = (const GLchar **)(&buffer);
 
     if(type == GL_FRAGMENT_SHADER)
     {
@@ -128,9 +163,8 @@ bool ShaderProgram::InstallShaderSourceFromFile(const char * const filename, GLe
     }
 
     delete [] buffer;
-    fclose(inFile);
   }
-  
+
   return bStatus;
 }
 

--- a/src/embedded_shaders.h
+++ b/src/embedded_shaders.h
@@ -1,0 +1,54 @@
+#ifndef EMBEDDED_SHADERS_H
+#define EMBEDDED_SHADERS_H
+
+#include <cstring>
+
+// Embeds the GLSL shader sources into the binary so the libretro core still has
+// a YCrCbA->RGB shader when no .vs/.fs files sit next to it (GetModuleFileName
+// resolves to the RetroArch binary, not the core).
+//
+// The .vs/.fs files remain the single source of truth: each one is guarded with
+//
+//   #ifdef EMBED_HLSL
+//   R"NUONSHADER(
+//   #endif
+//   ...shader code...
+//   #ifdef EMBED_HLSL
+//   )NUONSHADER"
+//   #endif
+//
+// so the same file is valid both as standalone GLSL (the guards are skipped by
+// the GLSL preprocessor) and, when included here with EMBED_HLSL defined, as a
+// C++ raw-string literal. The embedded copy therefore can never drift from the
+// on-disk source and there is no generated header.
+//
+// Caveat handled by ShaderProgram::InstallShaderSourceFromFile: because the raw
+// string opens right after the leading "#ifdef EMBED_HLSL", it captures that
+// guard's closing "#endif" at the very start and the trailing "#ifdef
+// EMBED_HLSL" at the very end. The embedded source is therefore wrapped in
+// "#if 1 ... #endif" before being handed to glShaderSource so those stray
+// directives stay balanced for the GLSL preprocessor.
+namespace {
+#define EMBED_HLSL
+static const char * const g_emb_video_generic_vs =
+#include "video_generic.vs"
+;
+static const char * const g_emb_video_m32_o32_fs =
+#include "video_m32_o32.fs"
+;
+static const char * const g_emb_video_m32_o32_crt_fs =
+#include "video_m32_o32_crt.fs"
+;
+#undef EMBED_HLSL
+}
+
+static inline const char *GetEmbeddedShaderSource(const char *filename)
+{
+  if(!filename) return nullptr;
+  if(strcmp(filename, "video_generic.vs") == 0) return g_emb_video_generic_vs;
+  if(strcmp(filename, "video_m32_o32.fs") == 0) return g_emb_video_m32_o32_fs;
+  if(strcmp(filename, "video_m32_o32_crt.fs") == 0) return g_emb_video_m32_o32_crt_fs;
+  return nullptr;
+}
+
+#endif // EMBEDDED_SHADERS_H

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -139,6 +139,11 @@ void UpdateTextureStates()
       shaderProgram.Uninitalize();
   }
 
+  // Only push uniforms if a valid program is bound. If shader install failed
+  // (e.g. source not found) GetProgramObject() is 0, and glGetUniformLocation
+  // on program 0 raises GL_INVALID_VALUE every frame.
+  if(bShadersInstalled)
+  {
   uint32 pixType = (structOverlayChannel.dmaflags >> 4) & 0x0F;
   uniformLoc = glGetUniformLocation(shaderProgram.GetProgramObject(), "structOverlayChannelAlpha");
   glUniform1f(uniformLoc, bOverlayChannelActive ? ((pixType == 2) ? (float)((double)structOverlayChannel.alpha*(1.0/255.0)) : -1.0f) : 1.0f);
@@ -151,6 +156,7 @@ void UpdateTextureStates()
   glUniform2f(uniformLoc, (float)display.clientWidth, (float)display.clientHeight);
   uniformLoc = glGetUniformLocation(shaderProgram.GetProgramObject(), "scaleInternal");
   glUniform4f(uniformLoc, (float)((double)structMainChannel.src_width * (1.0 / ALLOCATED_TEXTURE_WIDTH)), (float)((double)structMainChannel.src_height * (1.0 / ALLOCATED_TEXTURE_HEIGHT)), (float)((double)structOverlayChannel.src_width * (1.0 / ALLOCATED_TEXTURE_WIDTH)), (float)((double)structOverlayChannel.src_height * (1.0 / ALLOCATED_TEXTURE_HEIGHT)));
+  }
 
   glActiveTexture(mainTextureUnit);
 

--- a/video_generic.vs
+++ b/video_generic.vs
@@ -1,3 +1,6 @@
+#ifdef EMBED_HLSL
+R"NUONSHADER(
+#endif
 /*
 Nuance generic vertex shader for all pixel modes:
 
@@ -13,3 +16,6 @@ void main(void)
   gl_TexCoord[2] = gl_MultiTexCoord2;
   gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
 }
+#ifdef EMBED_HLSL
+)NUONSHADER"
+#endif

--- a/video_m32_o32.fs
+++ b/video_m32_o32.fs
@@ -1,3 +1,6 @@
+#ifdef EMBED_HLSL
+R"NUONSHADER(
+#endif
 /*
 Nuance pixel shader for 16/32-bit pixel modes:
 
@@ -170,3 +173,7 @@ void main()
 
   gl_FragColor = vec4(texture2D_composite(mainuv, overlayuv), 1.0);
 }
+
+#ifdef EMBED_HLSL
+)NUONSHADER"
+#endif

--- a/video_m32_o32_crt.fs
+++ b/video_m32_o32_crt.fs
@@ -1,3 +1,6 @@
+#ifdef EMBED_HLSL
+R"NUONSHADER(
+#endif
 /*
 Nuance pixel shader for 16/32-bit pixel modes:
 
@@ -217,3 +220,7 @@ void main()
 
   gl_FragColor = vec4(col,1.0);
 }
+
+#ifdef EMBED_HLSL
+)NUONSHADER"
+#endif


### PR DESCRIPTION
## Summary

The libretro core ships no `video_generic.vs` / `video_m32_o32*.fs` files next to it, and `InstallShaderSourceFromFile` only searches the CWD and the `GetModuleFileName` directory (the RetroArch binary, not the core). So the YCrCbA→RGB shader never compiled, `bShadersInstalled` stayed false, and `UpdateTextureStates` then called `glGetUniformLocation` on program 0 every frame → `GL_INVALID_VALUE` and a black screen even though the NUON video pipeline was active (canDisplay/mainActive/texInit all set).

- Embed the three shader sources into the binary (`embedded_shaders.h`) and use them as a fallback when no file is found, so an on-disk shader still overrides for development.
- Guard the per-frame uniform updates behind `bShadersInstalled` so a failed shader install can no longer spam GL errors.

Verified with RetroArch on Ballistic and Merlin Racing: `shaders=1`, `glErrPrevFrame=0x0000`, image renders correctly.