### PR TITLE
libretro: produce audio in retro_run and stop opening own miniaudio device

### DIFF
--- a/src/NuonEnvironment.cpp
+++ b/src/NuonEnvironment.cpp
@@ -95,6 +95,29 @@ void NuonEnvironment::InitAudio()
   if(nuonAudioPlaybackRate == 0 || nuonAudioBufferSize == 0) // delay init until SetAudioPlaybackRate and AudioSetChannelMode have been called, so we can configure rate/buffer here (also avoids one resampling step)
     return;
 
+#ifdef LIBRETRO
+  // Libretro core: RetroArch owns audio output - retro_run drains the ring via
+  // DrainAudioRing() and hands it to audio_batch_cb. We must NOT open our own
+  // miniaudio playback device here, or it would be a second consumer of the
+  // single-producer/single-consumer ring. Just (re)allocate the ring; reinit
+  // only when the period size or playback rate actually changes (this is called
+  // again from SetAudioPlaybackRate on every rate set, since audioDevice stays
+  // null in the libretro build).
+  {
+    const uint32 newPeriodBytes = nuonAudioBufferSize >> 1;
+    if(audioRing && audioRingPeriodBytes == newPeriodBytes && audioDeviceRate == nuonAudioPlaybackRate)
+      return;
+    audioRingPeriodBytes = newPeriodBytes;
+    audioRingSize        = AUDIO_RING_SLOTS * audioRingPeriodBytes;
+    delete[] audioRing;
+    audioRing = new uint8[audioRingSize];
+    audioRingWritePos.store(0, std::memory_order_relaxed);
+    audioRingReadPos.store(0, std::memory_order_relaxed);
+    audioDeviceRate = nuonAudioPlaybackRate; // also serves as the "initialized" sentinel
+  }
+  return;
+#else
+
   if(audioDevice)
     ma_device_uninit(audioDevice);
   else
@@ -142,6 +165,7 @@ void NuonEnvironment::InitAudio()
     audioDeviceRate = 0;
     return;
   }
+#endif // LIBRETRO
 }
 
 // Reset audio + MPE state to a "fresh boot", before loading a new game.

--- a/src/NuonEnvironment.h
+++ b/src/NuonEnvironment.h
@@ -140,6 +140,21 @@ public:
     return (nuonAudioChannelMode & ENABLE_SAMP_INT);
   }
 
+  // Wall-clock duration, in microseconds, that one pushed audio period
+  // (audioRingPeriodBytes = half the Nuon DMA buffer) represents when played
+  // back at the real Nuon rate. The host must pace pushes at this interval, NOT
+  // at the video-field rate: a period is half the DMA buffer, whose size the
+  // game picks freely (1K..64K), so "one period per 60Hz field" only happens to
+  // approximate 32kHz for ~4K buffers. Larger buffers overproduce (RetroArch's
+  // audio_sync then throttles the whole frontend); smaller ones underrun.
+  uint64 AudioPeriodIntervalUs() const
+  {
+    if(nuonAudioPlaybackRate == 0 || audioRingPeriodBytes == 0)
+      return 0;
+    const uint32 framesPerPeriod = audioRingPeriodBytes >> 2; // 4 bytes/frame (s16 stereo)
+    return ((uint64)framesPerPeriod * 1000000ull) / nuonAudioPlaybackRate;
+  }
+
   char *GetDVDBase() const
   {
     return dvdBase;

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -454,14 +454,17 @@ void retro_run(void)
             }
 
             // Audio: feed the host audio ring (RetroArch drains it via
-            // DrainAudioRing below). Mirrors the standalone main loop's audTimer:
-            // push one Nuon audio period when the game has re-armed its HALF/WRAP
-            // interrupt and INT_AUDIO is not already pending. Without this the
-            // libretro core never produces audio (the producer used to live only
-            // in the excluded standalone main loop).
-            if (nuonEnv.timer_rate[2] > 0) {
+            // DrainAudioRing below). Push one Nuon audio period when the game has
+            // re-armed its HALF/WRAP interrupt and INT_AUDIO is not already
+            // pending. The pacing interval is the period's TRUE playback duration
+            // at the Nuon rate (AudioPeriodIntervalUs), not the 60Hz video field:
+            // a period is half the game-chosen DMA buffer (1K..64K), so pacing on
+            // the field overproduces for >4K buffers (RetroArch audio_sync then
+            // throttles the whole frontend -> slowdown) and underruns for <4K.
+            const uint64 audioIntervalUs = nuonEnv.AudioPeriodIntervalUs();
+            if (audioIntervalUs > 0) {
                 if (nuonEnv.pNuonAudioBuffer &&
-                    (new_time >= last_time3 + (uint64)nuonEnv.timer_rate[2]) &&
+                    (new_time >= last_time3 + audioIntervalUs) &&
                     ((nuonEnv.nuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT)) != (nuonEnv.oldNuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT))) &&
                     ((((nuonEnv.mpe[0].intsrc & nuonEnv.mpe[0].inten1) | (nuonEnv.mpe[1].intsrc & nuonEnv.mpe[1].inten1) | (nuonEnv.mpe[2].intsrc & nuonEnv.mpe[2].inten1) | (nuonEnv.mpe[3].intsrc & nuonEnv.mpe[3].inten1)) & INT_AUDIO) == 0)) {
                     if (nuonEnv.TryPushAudioPeriod())

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -475,6 +475,7 @@ void retro_run(void)
     static uint64 last_time0 = useconds_since_start();
     static uint64 last_time1 = useconds_since_start();
     static uint64 last_time2 = useconds_since_start();
+    static uint64 last_time3 = useconds_since_start();
     const uint64 frame_budget_start = useconds_since_start();
     // During BIOS init (before video is configured), allow longer execution time
     // Use 100ms budget for first 100 frames to allow BIOS init to complete
@@ -523,6 +524,22 @@ void retro_run(void)
                     last_time2 = new_time;
                 }
             }
+
+            // Audio: feed the host audio ring (RetroArch drains it via
+            // DrainAudioRing below). Mirrors the standalone main loop's audTimer:
+            // push one Nuon audio period when the game has re-armed its HALF/WRAP
+            // interrupt and INT_AUDIO is not already pending. Without this the
+            // libretro core never produces audio (the producer used to live only
+            // in the excluded standalone main loop).
+            if (nuonEnv.timer_rate[2] > 0) {
+                if (nuonEnv.pNuonAudioBuffer &&
+                    (new_time >= last_time3 + (uint64)nuonEnv.timer_rate[2]) &&
+                    ((nuonEnv.nuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT)) != (nuonEnv.oldNuonAudioChannelMode & (ENABLE_WRAP_INT | ENABLE_HALF_INT))) &&
+                    ((((nuonEnv.mpe[0].intsrc & nuonEnv.mpe[0].inten1) | (nuonEnv.mpe[1].intsrc & nuonEnv.mpe[1].inten1) | (nuonEnv.mpe[2].intsrc & nuonEnv.mpe[2].inten1) | (nuonEnv.mpe[3].intsrc & nuonEnv.mpe[3].inten1)) & INT_AUDIO) == 0)) {
+                    if (nuonEnv.TryPushAudioPeriod())
+                        last_time3 = new_time;
+                }
+            } else last_time3 = new_time;
         }
 
         nuonEnv.TriggerScheduledInterrupts();


### PR DESCRIPTION
## Summary

The libretro core produced no sound, and once it did, emulation could run at a fraction of full speed. Three issues:

1. The audio period producer `TryPushAudioPeriod()` was only driven by the standalone main loop (`NuanceMain*.cpp`), which is excluded from the libretro build, so `retro_run` drained an always-empty ring.
2. `InitAudio()` opened its own miniaudio playback device even in the libretro build. Its `MiniAudioDataCallback` drained the audio ring in parallel with `retro_run`'s `DrainAudioRing`/`audio_batch_cb`, so two consumers raced on the SPSC ring's read position, giving choppy or no audio through RetroArch.
3. Once audio flowed, the producer pushed one period (half the Nuon DMA buffer) once per ~60Hz video field. But the DMA buffer size is game-chosen (1K..64K), so a period only equals ~1/60s of 32kHz audio for ~4K buffers. Games using larger buffers overproduced (an 8K buffer pushes 1024 frames/field = ~61kHz, ~2x realtime); with `audio_sync` + rate control RetroArch throttled the whole frontend down to play the surplus at 32kHz, so the core ran at roughly half speed. Smaller buffers underran (crackle).

This wires the audio-period push into `retro_run` (same condition the standalone loop uses), guards the miniaudio device setup behind `LIBRETRO` so the core only (re)allocates the ring and leaves RetroArch as the sole consumer via `DrainAudioRing`, and paces the push at the period's true playback duration (`AudioPeriodIntervalUs` = framesPerPeriod / playbackRate) instead of the video field. The host now emits a steady ~32kHz regardless of buffer size, keeping the existing one-interrupt-per-half HALF/WRAP producer semantics untouched.

Verified on hardware (KWin/Wayland, Mesa): Ballistic and Tempest 3000 both run at ~56-57 FPS with audio enabled.

- `src/libretro.cpp`: push one audio period per period-duration tick in `retro_run`.
- `src/NuonEnvironment.{h,cpp}`: add `AudioPeriodIntervalUs()`; `InitAudio()` libretro path allocates the ring only, no `ma_device`.
