### PR TITLE
info: Nuance is no longer experimental

### DIFF
--- a/dist/nuance_libretro.info
+++ b/dist/nuance_libretro.info
@@ -29,7 +29,7 @@ libretro_saves = "false"
 core_options = "false"
 core_options_version = "null"
 load_subsystem = "false"
-is_experimental = "true"
+is_experimental = "false"
 
 # Firmware / BIOS
 firmware_count = 3


### PR DESCRIPTION
Flips `is_experimental` to `false` in `dist/nuance_libretro.info`, so the core appears in RetroArch's core downloader without the user first enabling "Show experimental cores".

The frontend issues that made the flag fair are fixed: audio is produced from `retro_run` instead of the core opening its own mixer (#72), and the ARM64 build works (interpreter-only, #73). The core builds and runs on Linux x86_64 and aarch64 — the aarch64 nightly is on the libretro buildbot.

I have opened the matching change against libretro-super, which is where RetroArch actually reads the flag from: libretro/libretro-super#2035. This PR keeps the copy in this repository in sync.
