### PR TITLE
Build on macOS and 32-bit x86, and add CI for both

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,8 @@ libretro-build-windows-x64:
 # macOS 64-bit
 libretro-build-osx-x64:
   extends:
-    - .libretro-osx-cmake-x86
+    # -x86_64, not -x86: the latter is the 32-bit macOS class and sets ARCH=x86.
+    - .libretro-osx-cmake-x86_64
     - .core-defs
 
 # macOS ARM 64-bit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,10 @@ include:
     file: '/linux-cmake.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/windows-cmake-mingw.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-cmake-x86.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-cmake-arm64.yml'
 
 stages:
   - build-prepare
@@ -29,6 +33,14 @@ libretro-build-linux-x64:
     - .libretro-linux-cmake-x86_64
     - .core-defs
 
+# Linux 32-bit (i686). The x86 emitter this build uses is the one the project
+# started on, and the SSSE3 flag it needs is now applied wherever the compiler
+# takes it, so this is the same code path as x86_64 minus asmjit.
+libretro-build-linux-i686:
+  extends:
+    - .libretro-linux-cmake-x86
+    - .core-defs
+
 # Linux ARM 64-bit (aarch64). The buildbot provides an aarch64 image/runner
 # via .libretro-linux-cmake-aarch64.
 libretro-build-linux-aarch64:
@@ -39,4 +51,16 @@ libretro-build-linux-aarch64:
 libretro-build-windows-x64:
   extends:
     - .libretro-windows-cmake-x86_64
+    - .core-defs
+
+# macOS 64-bit
+libretro-build-osx-x64:
+  extends:
+    - .libretro-osx-cmake-x86
+    - .core-defs
+
+# macOS ARM 64-bit
+libretro-build-osx-arm64:
+  extends:
+    - .libretro-osx-cmake-arm64
     - .core-defs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,16 @@ else()
 endif()
 message(STATUS "NUANCE_X86_64 (asmjit JIT enabled) = ${NUANCE_X86_64} (processor: ${CMAKE_SYSTEM_PROCESSOR})")
 
+# The SSE/SSSE3 intrinsics in the emitters and the byteswap helpers are compiled
+# on every x86 target, not only the 64-bit one — on aarch64 they go through the
+# vendored sse2neon. x86_64 has SSE2 in its baseline so it only ever needed the
+# SSSE3 switch, but a 32-bit x86 build has neither on by default and fails in
+# emmintrin.h ("inlining failed in call to always_inline _mm_set_epi32").
+# Asking the compiler whether it takes the flag covers both without having to
+# recognise every spelling of the processor name; it is simply absent elsewhere.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-mssse3 NUANCE_HAS_MSSSE3)
+
 # asmjit (only used by the 64-bit JIT path; 32-bit keeps the legacy x86 emitter)
 if(NUANCE_X86_64)
     file(GLOB_RECURSE ASMJIT_SRC
@@ -174,7 +184,10 @@ if(BUILD_LIBRETRO)
     # the core uses its ResolveGameFile() to resolve ISO/ZIP/CHD inputs and to
     # read data files straight from the ISO at runtime (no whole-disc extraction),
     # so libchdr + miniz are linked in below for the libretro build too.
-    list(FILTER NUANCE_SOURCES EXCLUDE REGEX "NuanceMain|GLWindow|InputManager|NuanceUI")
+    # imgui_impl_x11 belongs with the other standalone-only files: the libretro
+    # build has no imgui (imgui_static is standalone-only) and pulling it in
+    # dragged X11 headers into a build that has none on macOS.
+    list(FILTER NUANCE_SOURCES EXCLUDE REGEX "NuanceMain|GLWindow|InputManager|NuanceUI|imgui_impl")
     add_library(nuance_libretro SHARED ${NUANCE_SOURCES} src/libretro.cpp)
     set_target_properties(nuance_libretro PROPERTIES PREFIX "" OUTPUT_NAME "nuance_libretro")
     target_compile_definitions(nuance_libretro PRIVATE LIBRETRO)
@@ -337,7 +350,7 @@ else()
     target_compile_options(${NUANCE_TARGET} PRIVATE
         -O3
         -ffast-math
-        $<$<BOOL:${NUANCE_X86_64}>:-mssse3>
+        $<$<BOOL:${NUANCE_HAS_MSSSE3}>:-mssse3>
         -Wno-multichar
         -Wno-write-strings
         -Wno-narrowing

--- a/src/EmitMEM.cpp
+++ b/src/EmitMEM.cpp
@@ -32,11 +32,8 @@ static inline void Emit_LoadBankPtr(EmitterVariables * const vars)
 #endif
   // 32-bit: entries are 4 bytes, ebx has index*4, scale=1 -> byte offset = index*4
   // The absolute address is emitted as a 32-bit displacement, so the pointer is
-  // truncated on purpose. Say so through uintptr_t: a direct pointer-to-int32
-  // cast is a warning on gcc but an error on clang, which is what kept this
-  // file — dead code on any non-x86 target, but still compiled there — from
-  // building on macOS and every other clang-hosted arch.
-  cc.X86Emit_MOVMR(x86Reg::x86Reg_ebx, x86BaseReg::x86BaseReg_ebx, x86IndexReg::x86IndexReg_none, x86ScaleVal::x86Scale_1, (int32)(uintptr_t)vars->mpe->bankPtrTable); //!! how does the latter part actually work?
+  // truncated on purpose. Say so through uintptr_t: a direct pointer-to-int32 cast errors on clang otherwise
+  cc.X86Emit_MOVMR(x86Reg::x86Reg_ebx, x86BaseReg::x86BaseReg_ebx, x86IndexReg::x86IndexReg_none, x86ScaleVal::x86Scale_1, (int32)(uintptr_t)vars->mpe->bankPtrTable);
 }
 
 static const __m128i bswap_lut = _mm_set_epi8(12,13,14,15, 8,9,10,11, 4,5,6,7, 0,1,2,3); //_mm_setr_epi8(3,2,1,0, 7,6,5,4, 11,10,9,8, 15,14,13,12);

--- a/src/EmitMEM.cpp
+++ b/src/EmitMEM.cpp
@@ -31,7 +31,12 @@ static inline void Emit_LoadBankPtr(EmitterVariables * const vars)
   }
 #endif
   // 32-bit: entries are 4 bytes, ebx has index*4, scale=1 -> byte offset = index*4
-  cc.X86Emit_MOVMR(x86Reg::x86Reg_ebx, x86BaseReg::x86BaseReg_ebx, x86IndexReg::x86IndexReg_none, x86ScaleVal::x86Scale_1, (int32)vars->mpe->bankPtrTable); //!! how does the latter part actually work?
+  // The absolute address is emitted as a 32-bit displacement, so the pointer is
+  // truncated on purpose. Say so through uintptr_t: a direct pointer-to-int32
+  // cast is a warning on gcc but an error on clang, which is what kept this
+  // file — dead code on any non-x86 target, but still compiled there — from
+  // building on macOS and every other clang-hosted arch.
+  cc.X86Emit_MOVMR(x86Reg::x86Reg_ebx, x86BaseReg::x86BaseReg_ebx, x86IndexReg::x86IndexReg_none, x86ScaleVal::x86Scale_1, (int32)(uintptr_t)vars->mpe->bankPtrTable); //!! how does the latter part actually work?
 }
 
 static const __m128i bswap_lut = _mm_set_epi8(12,13,14,15, 8,9,10,11, 4,5,6,7, 0,1,2,3); //_mm_setr_epi8(3,2,1,0, 7,6,5,4, 11,10,9,8, 15,14,13,12);

--- a/src/PatchManager.cpp
+++ b/src/PatchManager.cpp
@@ -20,7 +20,11 @@ void PatchManager::ApplyPatches()
         //*((uint64 *)(patchData[i].patchPtr)) = (uint64)(labelPointers[patchData[i].destLabel] - patchData[i].basePtr);
         break;
       case PatchType::PatchType_Abs32:
-        *((uint32 *)(patchData[i].patchPtr)) = (uint32)(labelPointers[patchData[i].destLabel]); //!! 64bit prob?
+        // Absolute 32-bit patch slot: the pointer is truncated by design (and
+        // only ever emitted by the 32-bit x86 backend). Written through
+        // uintptr_t because clang rejects the direct pointer-to-uint32 cast
+        // that gcc only warns about.
+        *((uint32 *)(patchData[i].patchPtr)) = (uint32)(uintptr_t)(labelPointers[patchData[i].destLabel]); //!! 64bit prob?
         break;
       case PatchType::PatchType_Abs64:
         //*((uint64 *)(patchData[i].patchPtr)) = (uint32)(labelPointers[patchData[i].destLabel]);

--- a/src/PatchManager.cpp
+++ b/src/PatchManager.cpp
@@ -21,10 +21,8 @@ void PatchManager::ApplyPatches()
         break;
       case PatchType::PatchType_Abs32:
         // Absolute 32-bit patch slot: the pointer is truncated by design (and
-        // only ever emitted by the 32-bit x86 backend). Written through
-        // uintptr_t because clang rejects the direct pointer-to-uint32 cast
-        // that gcc only warns about.
-        *((uint32 *)(patchData[i].patchPtr)) = (uint32)(uintptr_t)(labelPointers[patchData[i].destLabel]); //!! 64bit prob?
+        // only ever emitted by the 32-bit x86 backend!). Written through uintptr_t to please clang
+        *((uint32 *)(patchData[i].patchPtr)) = (uint32)(uintptr_t)(labelPointers[patchData[i].destLabel]);
         break;
       case PatchType::PatchType_Abs64:
         //*((uint64 *)(patchData[i].patchPtr)) = (uint32)(labelPointers[patchData[i].destLabel]);

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -12,7 +12,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <GL/glew.h>
-#include <GL/gl.h>
+// GL/gl.h is the Linux/Windows spelling; on macOS the header lives in the
+// OpenGL framework. Nothing here needs it either way — glew.h already declares
+// every entry point this file calls, and it must come first regardless.
 #include <mutex>
 #include <cstdarg>
 #ifdef _WIN32

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -12,9 +12,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <GL/glew.h>
-// GL/gl.h is the Linux/Windows spelling; on macOS the header lives in the
-// OpenGL framework. Nothing here needs it either way — glew.h already declares
-// every entry point this file calls, and it must come first regardless.
+// GL/gl.h not needed, glew.h already declares every entry point this file calls
 #include <mutex>
 #include <cstdarg>
 #ifdef _WIN32

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -566,7 +566,10 @@ void MediaRead(MPE &mpe)
           FILE* isoFp = ISO_FOPEN(g_ISOPath.c_str(), "rb");
           if(isoFp)
           {
-            const off64_t byteOffset = (off64_t)lba * 2048 + (off64_t)startblock * BLOCK_SIZE_DVD;
+            // int64_t rather than off64_t: the latter is a glibc type that
+            // macOS does not have (its off_t is already 64-bit), and ISO_FSEEK
+            // casts to whatever the platform's seek function takes anyway.
+            const int64_t byteOffset = (int64_t)lba * 2048 + (int64_t)startblock * BLOCK_SIZE_DVD;
             ISO_FSEEK(isoFp, byteOffset, SEEK_SET);
             readCount = (uint32)fread(intermediate.data(), BLOCK_SIZE_DVD, blockcount, isoFp);
             fclose(isoFp);

--- a/src/nativecodecache.cpp
+++ b/src/nativecodecache.cpp
@@ -75,8 +75,7 @@ bool NativeCodeCache::ReleaseBuffer(NativeCodeCacheEntryPoint entryPoint, uint32
     MessageBox(NULL, "VirtualProtect failed", "VirtualProtect failed", MB_OK);
 #endif
   }*/
-  // entryPoint is a function pointer and the shim takes void*. gcc converts that
-  // implicitly as an extension; clang requires the cast to be written out.
+  // entryPoint is a function pointer and the shim takes void*
   FlushInstructionCache(GetCurrentProcess(), (void *)entryPoint, newUsedBytes);
 
   if(alignment)

--- a/src/nativecodecache.cpp
+++ b/src/nativecodecache.cpp
@@ -75,7 +75,9 @@ bool NativeCodeCache::ReleaseBuffer(NativeCodeCacheEntryPoint entryPoint, uint32
     MessageBox(NULL, "VirtualProtect failed", "VirtualProtect failed", MB_OK);
 #endif
   }*/
-  FlushInstructionCache(GetCurrentProcess(), entryPoint, newUsedBytes);
+  // entryPoint is a function pointer and the shim takes void*. gcc converts that
+  // implicitly as an extension; clang requires the cast to be written out.
+  FlushInstructionCache(GetCurrentProcess(), (void *)entryPoint, newUsedBytes);
 
   if(alignment)
   {


### PR DESCRIPTION
The buildbot builds this core for Linux x86_64, Linux aarch64 and Windows x64. macOS and 32-bit Linux were missing, and adding the CI jobs alone would not have helped — the tree had never been compiled outside Linux on gcc, and six things were waiting there. Each one is a separate commit.

### What was in the way

**Casts gcc warns about and clang refuses.** A pointer truncated to `int32` in `EmitMEM.cpp`, the same to `uint32` in `PatchManager.cpp`, and a function pointer handed to the `FlushInstructionCache` shim, which takes `void*`. All three sit in code only the 32-bit x86 backend executes, but every target compiles it, so clang stopped at the first one. Written out through `uintptr_t`; x86 behaviour is unchanged.

**`imgui_impl_x11.cpp` in the libretro build.** The core has no imgui — `imgui_static` is added for the standalone build only — but that file was not in the filter with the other standalone-only sources, so the core pulled in X11 headers it never uses. Harmless on Linux, fatal anywhere without X11.

**`off64_t` in `media.cpp`.** A glibc type; macOS has no such name because its `off_t` is already 64-bit, which is why `ISO_FSEEK` has a branch for exactly that case.

**`<GL/gl.h>` in `libretro.cpp`.** The Linux/Windows spelling of a header macOS keeps in a framework. `GL/glew.h` has to come first anyway and declares everything the file calls, so the include just goes.

**`-mssse3` tied to `NUANCE_X86_64`.** The SSE intrinsics in the emitters and byteswap helpers are compiled for every x86 target — aarch64 reaches them through the vendored sse2neon — so a 32-bit x86 build met `emmintrin.h` with neither SSE2 nor SSSE3 on and died on an `always_inline` failure. The flag now follows `check_cxx_compiler_flag`, which covers both x86 targets and stays absent elsewhere.

### CI

`libretro-build-osx-x64`, `libretro-build-osx-arm64` via the `osx-cmake` templates, and `libretro-build-linux-i686` via `.libretro-linux-cmake-x86`.

### Tested

All three new targets build the core cleanly on GitHub Actions runners: **osx-arm64** and **osx-x64** (cross-compiled with `CMAKE_OSX_ARCHITECTURES`, the way the buildbot template does it) on macos-14, and **linux-i686** with gcc 13 `-m32` on ubuntu-24.04. The aarch64 tree also still builds with clang 21 locally, which is how I found the first three items.

**What I could not test:** running any of it — I have no Mac and no 32-bit x86 machine, so this is build verification only. And the buildbot's i386 image is xenial with gcc 9, which I have no way to reproduce; if C++20 there turns out to be a problem, the i686 job can be dropped without touching anything else.

One note on the diff: `EmitMEM.cpp`, `PatchManager.cpp`, `media.cpp` and `nativecodecache.cpp` are CRLF in the repo and stayed CRLF here, so the changes are the handful of lines they look like.