### PR TITLE
Build the libretro core for Android, iOS, tvOS and 32-bit Windows

### DIFF
--- a/.github/workflows/verify-platforms.yml
+++ b/.github/workflows/verify-platforms.yml
@@ -1,0 +1,115 @@
+name: verify new libretro targets
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [pr-platforms, gles-targets]
+
+jobs:
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Both slices on the Apple Silicon runner: the Intel ones queue for
+          # hours now, and the x86_64 slice cross-compiles the way the buildbot's
+          # osx-cmake template does anyway.
+          - { runner: macos-14, name: "osx-x64", arch: x86_64 }
+          - { runner: macos-14, name: "osx-arm64", arch: arm64 }
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v5
+        with: { submodules: recursive }
+      - run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO=ON -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -B build
+      - run: cmake --build build --parallel 3
+      - run: file build/nuance_libretro.* && ls -la build/nuance_libretro.*
+
+  linux_i686:
+    name: linux-i686
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with: { submodules: recursive }
+      - run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qy
+          sudo apt-get install -yq gcc-multilib g++-multilib libgl1-mesa-dev:i386 libx11-dev:i386 libglx-dev:i386
+      - run: cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO=ON -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_SYSTEM_PROCESSOR=i686 -B build
+      - run: cmake --build build --parallel 3
+      - run: file build/nuance_libretro.so
+
+  windows_i686:
+    name: windows-i686 (mingw)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with: { submodules: recursive }
+      - run: |
+          sudo apt-get update -qy
+          sudo apt-get install -yq mingw-w64
+      - run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO=ON \
+            -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=i686 \
+            -DCMAKE_C_COMPILER=i686-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=i686-w64-mingw32-g++ \
+            -DCMAKE_RC_COMPILER=i686-w64-mingw32-windres \
+            -DCMAKE_FIND_ROOT_PATH=/usr/i686-w64-mingw32 \
+            -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
+            -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+            -B build
+      - run: cmake --build build --parallel 3
+      - run: file build/nuance_libretro.dll && ls -la build/nuance_libretro.dll
+
+  android:
+    name: android-${{ matrix.abi }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, x86_64]
+    steps:
+      - uses: actions/checkout@v5
+        with: { submodules: recursive }
+      - run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO=ON \
+            -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake \
+            -DANDROID_ABI=${{ matrix.abi }} -DANDROID_PLATFORM=android-24 -DANDROID_STL=c++_static \
+            -B build
+      - run: cmake --build build --target nuance_libretro --parallel 3
+      - run: file build/nuance_libretro.so && ls -la build/nuance_libretro.so
+
+  ios:
+    name: ios-arm64
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+        with: { submodules: recursive }
+      - run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO=ON \
+            -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO \
+            -B build
+      - run: cmake --build build --target nuance_libretro --parallel 3
+      - run: find build -name 'nuance_libretro*' -exec file {} \;
+
+  # tvOS is in .gitlab-ci.yml as libretro-build-tvos-arm64 but was the one
+  # target nothing here ever compiled. It differs from iOS in ways that matter
+  # to this core - no shell, the same deprecated OpenGLES framework, its own
+  # deployment target for <filesystem> - so leaving it unbuilt would mean
+  # finding out on the buildbot.
+  tvos-arm64:
+    name: tvos-arm64
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+        with: { submodules: recursive }
+      - run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO=ON \
+            -DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO \
+            -B build
+      - run: cmake --build build --target nuance_libretro --parallel 3
+      - run: find build -name 'nuance_libretro*' -exec file {} \;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,12 @@ include:
     file: '/osx-cmake-x86.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-cmake-arm64.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-cmake.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ios-cmake.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/tvos-cmake.yml'
 
 stages:
   - build-prepare
@@ -53,6 +59,14 @@ libretro-build-windows-x64:
     - .libretro-windows-cmake-x86_64
     - .core-defs
 
+# Windows 32-bit (i686). The same code path as the 32-bit Linux job - the
+# legacy x86 emitter and the SSSE3 flag it needs - built with MinGW instead of
+# GCC. No asmjit here either: that is the 64-bit JIT.
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-cmake-x86
+    - .core-defs
+
 # macOS 64-bit
 libretro-build-osx-x64:
   extends:
@@ -64,4 +78,28 @@ libretro-build-osx-x64:
 libretro-build-osx-arm64:
   extends:
     - .libretro-osx-cmake-arm64
+    - .core-defs
+
+# The OpenGL ES targets. All three run the same code as the desktop builds -
+# interpreter, since none of them is x86-64 - with the renderer going through
+# vertex attributes and a GLES2 context instead of the fixed-function pipeline.
+libretro-build-android-arm64-v8a:
+  extends:
+    - .libretro-android-cmake-arm64-v8a
+    - .core-defs
+
+# The one Android ABI that takes the asmjit JIT path, being x86-64.
+libretro-build-android-x86_64:
+  extends:
+    - .libretro-android-cmake-x86_64
+    - .core-defs
+
+libretro-build-ios-arm64:
+  extends:
+    - .libretro-ios-cmake-arm64
+    - .core-defs
+
+libretro-build-tvos-arm64:
+  extends:
+    - .libretro-tvos-cmake-arm64
     - .core-defs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,38 @@ elseif(BUILD_LIBRETRO)
 else()
     find_package(SDL2 REQUIRED)
 endif()
-find_package(OpenGL REQUIRED)
+# Desktop OpenGL and GLEW, the loader for it, exist on Linux, Windows and macOS
+# and nowhere else: Android and iOS have OpenGL ES, which needs no loader and
+# has none of the fixed-function entry points this renderer uses. Asking for
+# them unconditionally is a configure-time failure on those platforms, before
+# any of that becomes the real question.
+if(IOS OR CMAKE_SYSTEM_NAME MATCHES "^(iOS|tvOS|watchOS)$")
+    set(NUANCE_APPLE_MOBILE ON)
+    # A framework is one linker argument in two words, which target_link_libraries
+    # splits into two items and then mangles into `-framework -lOpenGLES`. Asking
+    # find_library for it yields the path to link, which has no such problem.
+    find_library(NUANCE_OPENGLES_FRAMEWORK OpenGLES REQUIRED)
+else()
+    set(NUANCE_APPLE_MOBILE OFF)
+endif()
 
-# GLEW from bundled source
-add_library(glew_static STATIC external/glew.c)
-target_include_directories(glew_static PUBLIC external/glew-2.3.1/include)
-target_compile_definitions(glew_static PUBLIC GLEW_STATIC GLEW_NO_GLU)
-target_link_libraries(glew_static PUBLIC OpenGL::GL)
-set_property(TARGET glew_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+if(ANDROID OR NUANCE_APPLE_MOBILE)
+    set(NUANCE_GLES ON)
+else()
+    set(NUANCE_GLES OFF)
+endif()
+message(STATUS "NUANCE_GLES (OpenGL ES target) = ${NUANCE_GLES} (system: ${CMAKE_SYSTEM_NAME})")
+
+if(NOT NUANCE_GLES)
+    find_package(OpenGL REQUIRED)
+
+    # GLEW from bundled source
+    add_library(glew_static STATIC external/glew.c)
+    target_include_directories(glew_static PUBLIC external/glew-2.3.1/include)
+    target_compile_definitions(glew_static PUBLIC GLEW_STATIC GLEW_NO_GLU)
+    target_link_libraries(glew_static PUBLIC OpenGL::GL)
+    set_property(TARGET glew_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 
 ## miniaudio (single-TU implementation)
 add_library(miniaudio_impl STATIC external/miniaudio_impl.cpp)
@@ -236,6 +260,15 @@ target_compile_definitions(${NUANCE_TARGET} PRIVATE
     _CRT_SECURE_NO_WARNINGS
     _LARGEFILE64_SOURCE
     $<$<BOOL:${NUANCE_X86_64}>:USE_ASMJIT>
+    # Tells the sources they are building against OpenGL ES: no loader, no
+    # fixed-function matrix stack, and a GLES2 hardware context to ask for.
+    $<$<BOOL:${NUANCE_GLES}>:NUANCE_GLES>
+    $<$<BOOL:${NUANCE_APPLE_MOBILE}>:NUANCE_NO_SUBPROCESS>
+    # Apple deprecated the whole of OpenGL ES in iOS 12 and offers Metal
+    # instead. Until someone writes that renderer, every GL call this core
+    # makes is a warning - ninety-nine of them, which is enough to hide a real
+    # one. The deprecation is noted; silence it rather than reading past it.
+    $<$<BOOL:${NUANCE_APPLE_MOBILE}>:GLES_SILENCE_DEPRECATION>
 )
 
 # NuanceMain.cpp on Windows provides its own WinMain entry point.
@@ -249,8 +282,11 @@ if(WIN32 AND NOT BUILD_LIBRETRO)
 endif()
 
 target_link_libraries(${NUANCE_TARGET} PRIVATE
-    glew_static
-    miniaudio_impl
+    $<$<NOT:$<BOOL:${NUANCE_GLES}>>:glew_static>
+    # Standalone only, like SDL2: the libretro core hands its audio to
+    # RetroArch and never opens a device. On iOS miniaudio also reaches for the
+    # Objective-C audio backends, which a C++ build cannot compile.
+    $<$<NOT:$<BOOL:${BUILD_LIBRETRO}>>:miniaudio_impl>
     # libchdr (CHD reader) + its bundled miniz 3.1.1 (also doubles as the ZIP
     # reader for archive.cpp's Windows #ifdef path - configured with
     # MINIZ_ARCHIVE_APIS=ON above so mz_zip_reader_* is available). Needed by
@@ -259,13 +295,22 @@ target_link_libraries(${NUANCE_TARGET} PRIVATE
     miniz
     #murmurhash # unused - see add_library above
     $<$<BOOL:${NUANCE_X86_64}>:asmjit_static>
-    OpenGL::GL
+    # Desktop GL through the loader, or GLES2 linked straight in - on Android
+    # and iOS the library is part of the platform and there is nothing to load.
+    $<$<NOT:$<BOOL:${NUANCE_GLES}>>:OpenGL::GL>
+    # GLESv3 for the sized texture formats the video buffers use; the library
+    # also carries the ES 2 entry points, so there is nothing else to link.
+    # Apple has no such library - the same entry points live in a framework.
+    $<$<AND:$<BOOL:${NUANCE_GLES}>,$<NOT:$<BOOL:${NUANCE_APPLE_MOBILE}>>>:GLESv3>
+    $<$<BOOL:${NUANCE_APPLE_MOBILE}>:${NUANCE_OPENGLES_FRAMEWORK}>
     # SDL2 is a standalone-only dependency (windowing + audio); the libretro core
     # uses neither. Guarding it out also avoids a CMP0004 hard error when the
     # libretro build infra passes SDL2_LIBRARIES as a raw `sdl2-config --libs`
     # string (e.g. "-L/usr/lib/... -lSDL2 ") that has trailing whitespace.
     $<$<NOT:$<BOOL:${BUILD_LIBRETRO}>>:${SDL2_LIBRARIES}>
-    $<$<NOT:$<PLATFORM_ID:Windows>>:pthread>
+    # Bionic has the pthread functions in libc itself and ships no libpthread
+    # to link, so asking for one is an error rather than a no-op there.
+    $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<NOT:$<BOOL:${ANDROID}>>>:pthread>
     $<$<NOT:$<PLATFORM_ID:Windows>>:dl>
     $<$<NOT:$<PLATFORM_ID:Windows>>:m>
 )

--- a/src/NuonEnvironment.cpp
+++ b/src/NuonEnvironment.cpp
@@ -17,7 +17,13 @@
 #include "NuonMemoryMap.h"
 #include "byteswap.h"
 
+#ifndef LIBRETRO
+// Standalone only: in the libretro core RetroArch owns audio output, retro_run
+// drains the ring itself, and no playback device is ever opened. Including it
+// would also drag miniaudio's Objective-C backends into a C++ translation unit
+// on iOS, which is where this became more than dead weight.
 #include "miniaudio.h"
+#endif
 
 extern GLWindow display;
 
@@ -46,6 +52,7 @@ extern VidDisplay structMainDisplay;
       dst[i] = _byteswap_ushort(src[i]);
   }
 
+#ifndef LIBRETRO
   void NuonEnvironment::MiniAudioDataCallback(ma_device* pDevice, void* pOutput, const void* /*pInput*/, ma_uint32 frameCount)
   {
     NuonEnvironment* const nuonEnv = (NuonEnvironment*)pDevice->pUserData;
@@ -83,6 +90,7 @@ extern VidDisplay structMainDisplay;
     if(toCopy < bytesNeeded)
       memset((uint8*)pOutput + toCopy, 0, bytesNeeded - toCopy); // true underrun (producer behind)
   }
+#endif
 
 //InitAudio: Initialize miniaudio device for s16 stereo playback
 //Playback rate is the initially requested one (to avoid a resampling step), or 48000 Hz if exceeding supported ones,
@@ -198,6 +206,7 @@ void NuonEnvironment::ResetForReload()
 
 void NuonEnvironment::CloseAudio()
 {
+#ifndef LIBRETRO
   if(audioDevice)
   {
     MuteAudio(true);
@@ -206,6 +215,7 @@ void NuonEnvironment::CloseAudio()
     audioDevice = nullptr;
     audioDeviceRate = 0;
   }
+#endif
   delete[] audioRing;
   audioRing = nullptr;
   audioRingSize = 0;
@@ -245,8 +255,10 @@ void NuonEnvironment::RestartAudio()
 
 void NuonEnvironment::StopAudio()
 {
+#ifndef LIBRETRO
   if(audioDevice)
     ma_device_stop(audioDevice);
+#endif
 }
 
 void NuonEnvironment::SetAudioVolume(uint32 volume)
@@ -254,8 +266,10 @@ void NuonEnvironment::SetAudioVolume(uint32 volume)
   if(volume > 255)
     volume = 255;
   audioVolume = (float)volume / 255.0f;
+#ifndef LIBRETRO
   if(audioDevice)
     ma_device_set_master_volume(audioDevice, audioVolume);
+#endif
 }
 
 bool NuonEnvironment::TryPushAudioPeriod()

--- a/src/ShaderProgram.cpp
+++ b/src/ShaderProgram.cpp
@@ -30,14 +30,14 @@ bool ShaderProgram::Initialize()
 {  
   if(!hProgramObject)
   {
-    hProgramObject = glCreateProgramObjectARB();
+    hProgramObject = glCreateProgram();
     if(!hProgramObject)
     {
       return false;
     }
 
-    hVertexShaderObject = glCreateShaderObjectARB(GL_VERTEX_SHADER);
-    hFragmentShaderObject = glCreateShaderObjectARB(GL_FRAGMENT_SHADER);
+    hVertexShaderObject = glCreateShader(GL_VERTEX_SHADER);
+    hFragmentShaderObject = glCreateShader(GL_FRAGMENT_SHADER);
   }
 
   return true;
@@ -49,15 +49,15 @@ bool ShaderProgram::Uninitalize()
   {
     if(hVertexShaderObject)
     {
-      glDeleteObjectARB(hVertexShaderObject);
+      glDeleteShader(hVertexShaderObject);
     }
 
     if(hFragmentShaderObject)
     {
-      glDeleteObjectARB(hFragmentShaderObject);
+      glDeleteShader(hFragmentShaderObject);
     }
 
-    glDeleteObjectARB(hProgramObject);
+    glDeleteProgram(hProgramObject);
     hProgramObject = 0;
     hVertexShaderObject = 0;
     hFragmentShaderObject = 0;
@@ -68,15 +68,24 @@ bool ShaderProgram::Uninitalize()
   return true;
 }
 
-void ShaderProgram::PrintInfoLog(GLhandleARB obj, const char *msg)
+void ShaderProgram::PrintInfoLog(GLuint obj, const char *msg)
 {
+  // The ARB extension had one call for both; the core API this now uses - and
+  // the only one OpenGL ES has - splits them, so ask the object which it is.
+  const bool bIsShader = glIsShader(obj) == GL_TRUE;
   int32 blen = 0;   /* length of buffer to allocate */
-  glGetObjectParameterivARB(obj, GL_OBJECT_INFO_LOG_LENGTH_ARB , &blen);
+  if(bIsShader)
+    glGetShaderiv(obj, GL_INFO_LOG_LENGTH, &blen);
+  else
+    glGetProgramiv(obj, GL_INFO_LOG_LENGTH, &blen);
   if(blen > 1)
   {
     GLchar *infoLog = new GLchar[blen];
     int32 slen = 0;   /* strlen actually written to buffer */
-    glGetInfoLogARB(obj, blen, &slen, infoLog);
+    if(bIsShader)
+      glGetShaderInfoLog(obj, blen, &slen, infoLog);
+    else
+      glGetProgramInfoLog(obj, blen, &slen, infoLog);
     MessageBox(NULL,infoLog,msg,MB_OK);
     delete [] infoLog;
   }
@@ -147,7 +156,7 @@ bool ShaderProgram::InstallShaderSourceFromFile(const char * const filename, GLe
     {
       if(hFragmentShaderObject)
       {
-        glShaderSourceARB(hFragmentShaderObject,1,pBuffer,&length);
+        glShaderSource(hFragmentShaderObject,1,pBuffer,&length);
         bFragmentShaderCodeLoaded = true;
         bStatus = true;
       }
@@ -156,7 +165,7 @@ bool ShaderProgram::InstallShaderSourceFromFile(const char * const filename, GLe
     {
       if(hVertexShaderObject)
       {
-        glShaderSourceARB(hVertexShaderObject,1,pBuffer,NULL);
+        glShaderSource(hVertexShaderObject,1,pBuffer,NULL);
         bVertexShaderCodeLoaded = true;
         bStatus = true;
       }
@@ -176,7 +185,7 @@ bool ShaderProgram::InstallShaderSourceFromMemory(char **sourceStrings, uint32 c
   {
     if(hFragmentShaderObject)
     {
-      glShaderSourceARB(hFragmentShaderObject,count,(const char **)sourceStrings,lengths);
+      glShaderSource(hFragmentShaderObject,count,(const char **)sourceStrings,lengths);
       bFragmentShaderCodeLoaded = true;
       bStatus = true;
     }
@@ -185,7 +194,7 @@ bool ShaderProgram::InstallShaderSourceFromMemory(char **sourceStrings, uint32 c
   {
     if(hVertexShaderObject)
     {
-      glShaderSourceARB(hVertexShaderObject,1,(const char **)sourceStrings,lengths);
+      glShaderSource(hVertexShaderObject,1,(const char **)sourceStrings,lengths);
       bVertexShaderCodeLoaded = true;
       bStatus = true;
     }
@@ -203,8 +212,8 @@ bool ShaderProgram::CompileShader(GLenum type)
   {
     if(hFragmentShaderObject && bFragmentShaderCodeLoaded)
     {
-      glCompileShaderARB(hFragmentShaderObject);
-      glGetObjectParameterivARB(hFragmentShaderObject, GL_OBJECT_COMPILE_STATUS_ARB, &bCompiled);
+      glCompileShader(hFragmentShaderObject);
+      glGetShaderiv(hFragmentShaderObject, GL_COMPILE_STATUS, &bCompiled);
       bStatus = bCompiled;
     }
   }
@@ -212,8 +221,8 @@ bool ShaderProgram::CompileShader(GLenum type)
   {
     if(hVertexShaderObject && bVertexShaderCodeLoaded)
     {
-      glCompileShaderARB(hVertexShaderObject);
-      glGetObjectParameterivARB(hVertexShaderObject, GL_OBJECT_COMPILE_STATUS_ARB, &bCompiled);
+      glCompileShader(hVertexShaderObject);
+      glGetShaderiv(hVertexShaderObject, GL_COMPILE_STATUS, &bCompiled);
       bStatus = bCompiled;
     }
   }
@@ -226,9 +235,9 @@ bool ShaderProgram::Link()
   if(!hProgramObject || !(bVertexShaderObjectAttached || bFragmentShaderObjectAttached))
     return false;
 
-  glLinkProgramARB(hProgramObject);
+  glLinkProgram(hProgramObject);
   GLint bLinked = GL_FALSE;
-  glGetObjectParameterivARB(hProgramObject, GL_OBJECT_LINK_STATUS_ARB, &bLinked);
+  glGetProgramiv(hProgramObject, GL_LINK_STATUS, &bLinked);
   const bool bStatus = bLinked;
 
   return bStatus;
@@ -251,7 +260,7 @@ bool ShaderProgram::AttachShader(GLenum type)
     if(!bFragmentShaderObjectAttached)
     {
       bFragmentShaderObjectAttached = true;
-      glAttachObjectARB(hProgramObject,hFragmentShaderObject);
+      glAttachShader(hProgramObject,hFragmentShaderObject);
     }
   }
   else if(type == GL_VERTEX_SHADER)
@@ -264,7 +273,7 @@ bool ShaderProgram::AttachShader(GLenum type)
     if(!bVertexShaderObjectAttached)
     {
       bVertexShaderObjectAttached = true;
-      glAttachObjectARB(hProgramObject,hVertexShaderObject);
+      glAttachShader(hProgramObject,hVertexShaderObject);
     }
   } 
 
@@ -288,7 +297,7 @@ bool ShaderProgram::DetachShader(GLenum type)
     if(bFragmentShaderObjectAttached)
     {
       bFragmentShaderObjectAttached = false;
-      glDetachObjectARB(hProgramObject,hFragmentShaderObject);
+      glDetachShader(hProgramObject,hFragmentShaderObject);
     }
   }
   else if(type == GL_VERTEX_SHADER)
@@ -301,7 +310,7 @@ bool ShaderProgram::DetachShader(GLenum type)
     if(bVertexShaderObjectAttached)
     {
       bVertexShaderObjectAttached = false;
-      glDetachObjectARB(hProgramObject,hVertexShaderObject);
+      glDetachShader(hProgramObject,hVertexShaderObject);
     }
   } 
 
@@ -316,8 +325,8 @@ bool ShaderProgram::CompileAndLinkShaders()
   GLint bCompiled;
   if(hFragmentShaderObject && bFragmentShaderCodeLoaded)
   {
-    glCompileShaderARB(hFragmentShaderObject);
-    glGetObjectParameterivARB(hFragmentShaderObject, GL_OBJECT_COMPILE_STATUS_ARB, &bCompiled);
+    glCompileShader(hFragmentShaderObject);
+    glGetShaderiv(hFragmentShaderObject, GL_COMPILE_STATUS, &bCompiled);
     if(!bCompiled)
     {
       PrintInfoLog(hFragmentShaderObject,"Fragment Shader Compile Error");
@@ -327,8 +336,8 @@ bool ShaderProgram::CompileAndLinkShaders()
 
   if(hVertexShaderObject && bVertexShaderCodeLoaded)
   {
-    glCompileShaderARB(hVertexShaderObject);
-    glGetObjectParameterivARB(hVertexShaderObject, GL_OBJECT_COMPILE_STATUS_ARB, &bCompiled);
+    glCompileShader(hVertexShaderObject);
+    glGetShaderiv(hVertexShaderObject, GL_COMPILE_STATUS, &bCompiled);
     if(!bCompiled)
     {
       PrintInfoLog(hVertexShaderObject,"Vertex Shader Compile Error");
@@ -336,9 +345,9 @@ bool ShaderProgram::CompileAndLinkShaders()
     }
   }
 
-  glLinkProgramARB(hProgramObject);
+  glLinkProgram(hProgramObject);
   GLint bLinked;
-  glGetObjectParameterivARB(hProgramObject, GL_OBJECT_LINK_STATUS_ARB, &bLinked);
+  glGetProgramiv(hProgramObject, GL_LINK_STATUS, &bLinked);
   const bool bStatus = bLinked;
   if(!bLinked)
   {
@@ -349,12 +358,12 @@ bool ShaderProgram::CompileAndLinkShaders()
 
 bool ShaderProgram::StartShaderProgram()
 {
-  glUseProgramObjectARB(hProgramObject);
+  glUseProgram(hProgramObject);
   return true;
 }
 
 bool ShaderProgram::StopShaderProgram()
 {
-  glUseProgramObjectARB(0);
+  glUseProgram(0);
   return true;
 }

--- a/src/ShaderProgram.h
+++ b/src/ShaderProgram.h
@@ -2,7 +2,7 @@
 #define SHADERPROGRAM_H
 
 #include "basetypes.h"
-#include <GL/glew.h>
+#include "gl_headers.h"
 
 class ShaderProgram final
 {
@@ -18,20 +18,20 @@ public:
   bool InstallShaderSourceFromMemory(char **sourceStrings, uint32 count, const int *lengths, GLenum type);
   bool CompileShader(GLenum type);
   bool Link();
-  void PrintInfoLog(GLhandleARB obj, const char *msg);
+  void PrintInfoLog(GLuint obj, const char *msg);
   bool AttachShader(GLenum type);
   bool DetachShader(GLenum type);
   bool CompileAndLinkShaders();
   bool StartShaderProgram();
   bool StopShaderProgram();
-  GLhandleARB GetProgramObject() { return hProgramObject; }
-  GLhandleARB GetVertexShaderObject() { return hVertexShaderObject; }
-  GLhandleARB GetFragmentShaderObject() { return hFragmentShaderObject; }
+  GLuint GetProgramObject() { return hProgramObject; }
+  GLuint GetVertexShaderObject() { return hVertexShaderObject; }
+  GLuint GetFragmentShaderObject() { return hFragmentShaderObject; }
 
 private:
-  GLhandleARB hVertexShaderObject;
-  GLhandleARB hFragmentShaderObject;
-  GLhandleARB hProgramObject;
+  GLuint hVertexShaderObject;
+  GLuint hFragmentShaderObject;
+  GLuint hProgramObject;
   bool bVertexShaderObjectAttached;
   bool bFragmentShaderObjectAttached;
   bool bVertexShaderCodeLoaded;

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -6,6 +6,11 @@
 #include <cstdlib>
 #include <vector>
 #include <string>
+#ifdef NUANCE_NO_SUBPROCESS
+  // Not <filesystem>: its declarations are marked unavailable below iOS 13,
+  // and the deployment target here is lower than that.
+  #include <ftw.h>
+#endif
 
 #include "libchdr/chd.h"
 
@@ -319,6 +324,21 @@ bool ExtractZipBootOrIso(const char* zipPath, const std::string& tempDir, std::s
   return !outBoot.empty() || !outIso.empty();
 }
 
+#elif defined(NUANCE_NO_SUBPROCESS)
+
+// iOS and tvOS have neither system() nor popen(), and none of fuseiso,
+// fuse-zip, archivemount or 7z exists to call even if they did. The in-process
+// readers above - miniz for zip, libchdr for chd, iso9660 for iso - cover
+// every format this path was a fallback for, so it stands down rather than
+// pretending to mount something.
+std::string MountPath(const char*) { return ""; }
+
+std::string MountAndFind(const char* archivePath)
+{
+  fprintf(stderr, "Cannot mount %s: this platform has no external archive tools\n", archivePath);
+  return "";
+}
+
 #else // _WIN32 // Linux-only: FUSE-based mount / extract logic
 
 std::string PopenLine(const std::string& cmd)
@@ -488,6 +508,15 @@ void CleanupArchives()
     op.pFrom  = from;
     op.fFlags = FOF_NO_UI;
     SHFileOperationA(&op);
+  }
+  g_tempPaths.clear();
+#elif defined(NUANCE_NO_SUBPROCESS)
+  // Nothing is ever mounted here - see MountPath above - so there is only what
+  // the in-process extractors wrote, and removing that needs no shell.
+  for (auto& d : g_tempPaths) {
+    nftw(d.c_str(),
+         [](const char* p, const struct stat*, int, struct FTW*) { return remove(p); },
+         8, FTW_DEPTH | FTW_PHYS); // depth-first, so a directory goes after what is in it
   }
   g_tempPaths.clear();
 #else

--- a/src/gl_headers.h
+++ b/src/gl_headers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// One place that decides which GL headers the core gets. Desktop builds go
+// through GLEW, which loads the entry points at runtime; OpenGL ES has no
+// loader - the platform library exports everything - and including glew.h
+// there fails outright ("gl2.h included before glew.h") before it gets as far
+// as the entry points it declares that GLES does not have.
+#if defined(NUANCE_GLES)
+// ES 3.0: GL_RGBA8, GL_RG8 and GL_RG, which the video buffers are declared
+// with and ES 2 does not have. gl3.h includes the ES 2 entry points as well.
+#if defined(__APPLE__)
+// Apple puts the same headers inside the OpenGLES framework under names of
+// its own; there is no GLES3/gl3.h to find on iOS or tvOS.
+#include <OpenGLES/ES3/gl.h>
+#include <OpenGLES/ES3/glext.h>
+#else
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+#endif
+#else
+#include <GL/glew.h>
+#endif

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -11,8 +11,10 @@
 #include <vector>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <GL/glew.h>
-// GL/gl.h not needed, glew.h already declares every entry point this file calls
+#include "gl_headers.h"
+// GL/gl.h not needed; the header above already brings in every entry point
+// this file calls, whether that is GLEW on the desktop or the platform's own
+// GLES headers.
 #include <mutex>
 #include <cstdarg>
 #ifdef _WIN32
@@ -142,6 +144,9 @@ static uint16 GetInputButtons()
 
 static void context_reset(void)
 {
+#if defined(NUANCE_GLES)
+    log_printf("libretro: GLES context, no loader needed\n");
+#else
     glewExperimental = GL_TRUE;
     GLenum glew_err = glewInit();
     // GLEW often reports GLEW_ERROR_NO_GL_VERSION on core/forward-compatible contexts
@@ -152,6 +157,7 @@ static void context_reset(void)
         return;
     }
     log_printf("libretro: GL context reset OK (GL %s)\n", (const char*)glGetString(GL_VERSION));
+#endif
 
     gl_initialized = true;
 
@@ -175,11 +181,16 @@ static void context_reset(void)
 
     // Setup GL state
     glViewport(0, 0, FB_WIDTH, FB_HEIGHT);
+#if !defined(NUANCE_GLES)
+    // The matrix stack is only still here for the no-shader fallback: the
+    // shader path gets the same projection through the u_mvp uniform, and GLES
+    // has no fixed-function matrices at all.
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glOrtho(0.0, 1.0, 0.0, 1.0, -1.0, 1.0);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
+#endif
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_BLEND);
     glClearColor(0, 0, 0, 1);
@@ -282,7 +293,15 @@ bool retro_load_game(const struct retro_game_info *game)
     // Defer CPU init to context_reset to avoid potential issues
 
     // Request OpenGL context
+#if defined(NUANCE_GLES)
+    // Android, iOS and tvOS have OpenGL ES and nothing else. Version 3 rather
+    // than 2 for one reason: the texture formats. GL_RGBA8, GL_RG8 and GL_RG
+    // are what the video buffers are declared with, and ES2 has no sized
+    // internal formats and no two-channel one at all.
+    hw_render.context_type = RETRO_HW_CONTEXT_OPENGLES3;
+#else
     hw_render.context_type = RETRO_HW_CONTEXT_OPENGL;
+#endif
     hw_render.context_reset = context_reset;
     hw_render.context_destroy = context_destroy;
     hw_render.depth = false;

--- a/src/linux_compat.h
+++ b/src/linux_compat.h
@@ -9,6 +9,9 @@
 
 #include <cstdint>
 #include <cstdio>
+#if defined(__APPLE__)
+#include <libkern/OSCacheControl.h> // sys_icache_invalidate, for FlushInstructionCache below
+#endif
 #include <cstring>
 #include <cstdlib>
 #include <climits>
@@ -269,7 +272,15 @@ inline int VirtualFree(void* addr, size_t size, unsigned int) {
 
 // FlushInstructionCache
 inline int FlushInstructionCache(void*, void* addr, size_t size) {
+#if defined(__APPLE__)
+    // Apple ships no __clear_cache: the builtin lowers to a call into libgcc
+    // or compiler-rt, and neither is linked here, so it ends up undefined at
+    // link time. sys_icache_invalidate is what the platform offers instead,
+    // and on x86 it is a no-op the same way the builtin is.
+    sys_icache_invalidate(addr, size);
+#else
     __builtin___clear_cache((char*)addr, (char*)addr + size);
+#endif
     return 1;
 }
 inline void* GetCurrentProcess() { return nullptr; }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2,7 +2,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <mutex>
-#include <GL/glew.h>
+#include "gl_headers.h"
 
 #include "GLWindow.h"
 #include "Bios.h"
@@ -40,7 +40,13 @@ constexpr GLint mainInternalTextureFormat32 = GL_RGBA8;
 constexpr GLint mainInternalTextureFormat16 = GL_RG8;
 constexpr GLint mainInternalTextureBPC32 = 4;
 constexpr GLint mainInternalTextureBPC16 = 2;
+// OpenGL ES has no BGRA at all, so the same bytes are uploaded as RGBA and the
+// fragment shader skips the swizzle it does on desktop (NUON_TEXEL3/4).
+#if defined(NUANCE_GLES)
+constexpr GLint mainExternalTextureFormat32 = GL_RGBA;
+#else
 constexpr GLint mainExternalTextureFormat32 = GL_BGRA;
+#endif
 constexpr GLint mainExternalTextureFormat16 = GL_RG;
 constexpr GLint mainPixelType32 = GL_UNSIGNED_BYTE;
 constexpr GLint mainPixelType16 = GL_UNSIGNED_BYTE;
@@ -50,7 +56,11 @@ constexpr GLint osdInternalTextureFormat32 = GL_RGBA8;
 constexpr GLint osdInternalTextureFormat16 = GL_RG8;
 constexpr GLint osdInternalTextureBPC32 = 4;
 constexpr GLint osdInternalTextureBPC16 = 2;
+#if defined(NUANCE_GLES)
+constexpr GLint osdExternalTextureFormat32 = GL_RGBA;
+#else
 constexpr GLint osdExternalTextureFormat32 = GL_BGRA;
+#endif
 constexpr GLint osdExternalTextureFormat16 = GL_RG;
 constexpr GLint osdPixelType32 = GL_UNSIGNED_BYTE;
 constexpr GLint osdPixelType16 = GL_UNSIGNED_BYTE;
@@ -185,23 +195,37 @@ void UpdateTextureStates()
     videoTexInfo.mainTexCoords[5] = yf;
     videoTexInfo.mainTexCoords[6] = xf;
     videoTexInfo.mainTexCoords[7] = y0;
+#if !defined(NUANCE_GLES)
 
     glEnable(TEXTURE_TARGET);
+#endif
     glBindTexture(TEXTURE_TARGET, videoTexInfo.mainTexName);
   }
   else
   {
     glBindTexture(TEXTURE_TARGET, videoTexInfo.borderTexName);
     glTexImage2D(TEXTURE_TARGET,0,mainInternalTextureFormat32,2,2,0,mainExternalTextureFormat32, mainPixelType32,borderTexture);
+#if !defined(NUANCE_GLES)
     glDisable(TEXTURE_TARGET);
+#endif
   }
 
+#if defined(NUANCE_GLES)
+  // Neither the border colour nor GL_CLAMP_TO_BORDER exists in the OpenGL ES
+  // core. Clamping to the edge is the nearest behaviour, and it differs only
+  // where the quad samples outside the buffer.
+  glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#else
   glTexParameterfv(TEXTURE_TARGET, GL_TEXTURE_BORDER_COLOR, videoTexInfo.borderColor);
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+#endif
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_MIN_FILTER, filterType);
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_MAG_FILTER, filterType);
-  glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+#if !defined(NUANCE_GLES)
+  glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE); // fixed-function, no-shader path only
+#endif
 
   glActiveTexture(osdTextureUnit);
 
@@ -230,38 +254,60 @@ void UpdateTextureStates()
     //  pBuffer[3] = videoTexInfo.transColor[3];
     //  pBuffer += 4;
     //}
+#if !defined(NUANCE_GLES)
 
     glEnable(TEXTURE_TARGET);
+#endif
     glBindTexture(TEXTURE_TARGET, videoTexInfo.osdTexName);
   }
   else
   {
     glBindTexture(TEXTURE_TARGET, videoTexInfo.transparencyTexName);
     glTexImage2D(TEXTURE_TARGET,0,osdInternalTextureFormat32,2,2,0,osdExternalTextureFormat32, osdPixelType32,transparencyTexture);
+#if !defined(NUANCE_GLES)
     glDisable(TEXTURE_TARGET);
+#endif
   }
 
+#if defined(NUANCE_GLES)
+  // As above: no border colour and no GL_CLAMP_TO_BORDER in the ES core.
+  glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#else
   glTexParameterfv(TEXTURE_TARGET, GL_TEXTURE_BORDER_COLOR, videoTexInfo.transColor);
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+#endif
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_MIN_FILTER, filterType);
   glTexParameteri(TEXTURE_TARGET, GL_TEXTURE_MAG_FILTER, filterType);
-  glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_DECAL);
+#if !defined(NUANCE_GLES)
+  glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_DECAL); // fixed-function, no-shader path only
+#endif
 
   glActiveTexture(lutTextureUnit);
+#if !defined(NUANCE_GLES)
   glEnable(GL_TEXTURE_2D);
+#endif
   glBindTexture(GL_TEXTURE_2D, videoTexInfo.LUTTexName);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+#if !defined(NUANCE_GLES)
+  glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE); // fixed-function, no-shader path only
+#endif
 
   if(bUseSeparateThread) gfx_lock.unlock();
 }
 
 void UpdateDisplayList()
 {
+#if defined(NUANCE_GLES)
+  // Display lists went out with the compatibility profile and OpenGL ES never
+  // had them. They are only still built for the no-shader fallback, which
+  // cannot run here either - DrawChannelQuadWithAttributes is what draws on ES.
+  return;
+#else
   if(bUseSeparateThread) gfx_lock.lock();
 
   if(!glIsList(videoTexInfo.displayListName[0]))
@@ -351,6 +397,7 @@ void UpdateDisplayList()
   }
 
   if(bUseSeparateThread) gfx_lock.unlock();
+#endif
 }
 
 void InitTextures()
@@ -422,6 +469,64 @@ void VideoInvalidateGLState()
   bOverlayTexturePixType = -1;
 }
 
+
+// Draws the output quad with explicit vertex attributes instead of a display
+// list full of glMultiTexCoord2fv/glVertex2f. Immediate mode, display lists and
+// the fixed-function matrix are compatibility-profile features that OpenGL ES
+// does not have, so this is the path that can run on Android and iOS; it feeds
+// video_generic.vs exactly the values the display list used to pass.
+//
+// Only usable with the shader program - the no-shader fallback still relies on
+// the fixed-function texture environment, and keeps the display list below.
+static void DrawChannelQuadWithAttributes(const uint32 activeChannels)
+{
+  const GLuint program = shaderProgram.GetProgramObject();
+  if(!program)
+    return;
+
+  // The corners the display list emitted, in the same order: (0,0) (0,1) (1,1) (1,0).
+  static const float positions[8] = { 0.f,0.f, 0.f,1.f, 1.f,1.f, 1.f,0.f };
+  // glOrtho(0,1, 0,1, -1,1), which is what the client set on the fixed-function
+  // projection matrix, written out column-major for glUniformMatrix4fv.
+  static const float orthoMvp[16] = {
+    2.f, 0.f,  0.f, 0.f,
+    0.f, 2.f,  0.f, 0.f,
+    0.f, 0.f, -1.f, 0.f,
+   -1.f,-1.f,  0.f, 1.f };
+
+  const bool bMain = (activeChannels & CHANNELSTATE_MAIN_ACTIVE) != 0;
+  const bool bOverlay = (activeChannels & CHANNELSTATE_OVERLAY_ACTIVE) != 0;
+
+  // A channel that is not active gets its coordinates from an active one rather
+  // than a dangling pointer; the shader ignores them in that case.
+  const float * const mainTC = bMain ? videoTexInfo.mainTexCoords : videoTexInfo.osdTexCoords;
+  const float * const osdTC = bOverlay ? videoTexInfo.osdTexCoords : videoTexInfo.mainTexCoords;
+
+  const GLint locMvp = glGetUniformLocation(program, "u_mvp");
+  if(locMvp >= 0)
+    glUniformMatrix4fv(locMvp, 1, GL_FALSE, orthoMvp);
+
+  const GLint locPos = glGetAttribLocation(program, "a_position");
+  const GLint locTc0 = glGetAttribLocation(program, "a_texcoord0");
+  const GLint locTc1 = glGetAttribLocation(program, "a_texcoord1");
+  const GLint locTc2 = glGetAttribLocation(program, "a_texcoord2");
+  if(locPos < 0)
+    return;
+
+  glEnableVertexAttribArray(locPos);
+  glVertexAttribPointer(locPos, 2, GL_FLOAT, GL_FALSE, 0, positions);
+  if(locTc0 >= 0) { glEnableVertexAttribArray(locTc0); glVertexAttribPointer(locTc0, 2, GL_FLOAT, GL_FALSE, 0, mainTC); }
+  if(locTc1 >= 0) { glEnableVertexAttribArray(locTc1); glVertexAttribPointer(locTc1, 2, GL_FLOAT, GL_FALSE, 0, osdTC); }
+  if(locTc2 >= 0) { glEnableVertexAttribArray(locTc2); glVertexAttribPointer(locTc2, 2, GL_FLOAT, GL_FALSE, 0, videoTexInfo.windowTexCoords); }
+
+  glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+  glDisableVertexAttribArray(locPos);
+  if(locTc0 >= 0) glDisableVertexAttribArray(locTc0);
+  if(locTc1 >= 0) glDisableVertexAttribArray(locTc1);
+  if(locTc2 >= 0) glDisableVertexAttribArray(locTc2);
+}
+
 void RenderVideo(const int winwidth, const int winheight)
 {
   if(!bCanDisplayVideo)
@@ -458,11 +563,15 @@ void RenderVideo(const int winwidth, const int winheight)
     if(bUseSeparateThread) gfx_lock.lock();
 
     glViewport(0,0,winwidth,winheight);
+#if !defined(NUANCE_GLES)
+    // The shader path gets this same projection through u_mvp; the matrix stack
+    // is only still set up for the no-shader fallback, and ES has none.
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glOrtho(0.0,1.0,0.0,1.0,-1.0,1.0);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
+#endif
 
     if(bUseSeparateThread) gfx_lock.unlock();
     bSetupViewport = true;
@@ -856,7 +965,16 @@ render_main_buffer:
 
   if(bUseSeparateThread) gfx_lock.lock();
 
-  glCallList(videoTexInfo.displayListName[activeChannels]);
+#if defined(NUANCE_GLES)
+  // There is no fallback on ES: without the shader program there is nothing to
+  // draw with, and the display list it would call does not exist.
+  DrawChannelQuadWithAttributes(activeChannels);
+#else
+  if(bShadersInstalled)
+    DrawChannelQuadWithAttributes(activeChannels);
+  else
+    glCallList(videoTexInfo.displayListName[activeChannels]);
+#endif
   //glFlush();
 #ifdef _WIN32
   SwapBuffers(display.hDC);
@@ -1523,6 +1641,7 @@ void VidSetCLUTRange(MPE &mpe)
 void VideoCleanup()
 {
   if(bUseSeparateThread) gfx_lock.lock();
+#if !defined(NUANCE_GLES)
   for(uint32 i = 0; i < 4; i++)
   {
     if(glIsList(videoTexInfo.displayListName[i]))
@@ -1530,5 +1649,6 @@ void VideoCleanup()
       glDeleteLists(videoTexInfo.displayListName[i],1);
     }
   }
+#endif
   if(bUseSeparateThread) gfx_lock.unlock();
 }

--- a/src/video.h
+++ b/src/video.h
@@ -3,7 +3,7 @@
 
 #include "basetypes.h"
 #include "mpe.h"
-#include <GL/glew.h>
+#include "gl_headers.h"
 
 #define NUON_VIDEO_SYSTEM 1 // 0 PAL, 1 NTSC
 

--- a/video_generic.vs
+++ b/video_generic.vs
@@ -9,12 +9,31 @@ glMultiTexCoord and then sets gl_Position with the transformed vertex
 coordinate.
 */
 
-void main(void) 
+#ifdef GL_ES
+precision highp float;
+#endif
+
+// Explicit attributes and varyings rather than gl_MultiTexCoord/gl_TexCoord and
+// the fixed-function matrix: those are compatibility-profile built-ins that
+// OpenGL ES does not have at all, and the client feeds these the same values it
+// used to pass through glMultiTexCoord2fv.
+attribute vec4 a_position;
+attribute vec2 a_texcoord0;
+attribute vec2 a_texcoord1;
+attribute vec2 a_texcoord2;
+
+uniform mat4 u_mvp;
+
+varying vec2 v_texcoord0;
+varying vec2 v_texcoord1;
+varying vec2 v_texcoord2;
+
+void main(void)
 {
-  gl_TexCoord[0] = gl_MultiTexCoord0;
-  gl_TexCoord[1] = gl_MultiTexCoord1;
-  gl_TexCoord[2] = gl_MultiTexCoord2;
-  gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+  v_texcoord0 = a_texcoord0;
+  v_texcoord1 = a_texcoord1;
+  v_texcoord2 = a_texcoord2;
+  gl_Position = u_mvp * a_position;
 }
 #ifdef EMBED_HLSL
 )NUONSHADER"

--- a/video_m32_o32.fs
+++ b/video_m32_o32.fs
@@ -25,6 +25,28 @@ are being biased to [-0.5,0.5] unlike when using the imaging subset where
 all intermediate values are required to stay within the range [0.0,1.0]
 */
 
+#ifdef GL_ES
+precision highp float;
+#endif
+
+// Fed by video_generic.vs. These replace gl_TexCoord[0..2], which is a
+// compatibility built-in and does not exist in OpenGL ES.
+// The NUON framebuffer goes to the GPU as raw bytes. Desktop uploads them with
+// GL_BGRA, so the driver reorders and the shader takes .bgr to get back to the
+// original byte order; OpenGL ES has no BGRA, uploads the same bytes as GL_RGBA
+// and therefore wants no reordering at all. Same pixels either way.
+#ifdef GL_ES
+#define NUON_TEXEL3(t) (t).rgb
+#define NUON_TEXEL4(t) (t).rgba
+#else
+#define NUON_TEXEL3(t) (t).bgr
+#define NUON_TEXEL4(t) (t).bgra
+#endif
+
+varying vec2 v_texcoord0;
+varying vec2 v_texcoord1;
+varying vec2 v_texcoord2;
+
 uniform sampler2D mainChannelSampler;
 uniform sampler2D overlayChannelSampler;
 uniform sampler2D LUTSampler;
@@ -79,7 +101,7 @@ vec3 texture2D_main(vec2 uv_org)
       uv = clamp(uv,vec2(0.,0.),vec2((720.0-1.0)*scaleInternal.x,(resy-1.)*scaleInternal.y));
       uv *= vec2(0.0013888889,1./resy); // 1./720
 
-      mainColor = texture2D(mainChannelSampler, uv).bgr; //!! throws away alpha, but should not matter as this is the final displayed buffer anyway!
+      mainColor = NUON_TEXEL3(texture2D(mainChannelSampler, uv)); //!! throws away alpha, but should not matter as this is the final displayed buffer anyway!
     }
 
     mainColor = clamp(mainColor*expansion-preBiasExpansion, 0.0, 1.0);
@@ -128,7 +150,7 @@ vec4 texture2D_overlay(vec2 uv_org)
       uv = clamp(uv,vec2(0.,0.),vec2((720.0-1.0)*scaleInternal.z,(resy-1.)*scaleInternal.w));
       uv *= vec2(0.0013888889,1./resy); // 1./720
 
-      overlayColor = texture2D(overlayChannelSampler, uv).bgra;
+      overlayColor = NUON_TEXEL4(texture2D(overlayChannelSampler, uv));
     }
 
     if(overlayColor.xyz == vec3(0.0,0.0,0.0)) // invalid overlay pixel -> fully transparent overlay pixel //!! should this also be interpolated??
@@ -168,8 +190,8 @@ vec3 texture2D_composite(vec2 mainuv, vec2 overlayuv)
 
 void main()
 {
-  vec2 mainuv    = gl_TexCoord[0].st*vec2(720.,resy)-0.499; //!! 0.499 because of precision problems if src width/height is rather small (Space Invaders XL)
-  vec2 overlayuv = gl_TexCoord[1].st*vec2(720.,resy)-0.499; //!! dto.
+  vec2 mainuv    = v_texcoord0*vec2(720.,resy)-0.499; //!! 0.499 because of precision problems if src width/height is rather small (Space Invaders XL)
+  vec2 overlayuv = v_texcoord1*vec2(720.,resy)-0.499; //!! dto.
 
   gl_FragColor = vec4(texture2D_composite(mainuv, overlayuv), 1.0);
 }

--- a/video_m32_o32_crt.fs
+++ b/video_m32_o32_crt.fs
@@ -25,6 +25,28 @@ are being biased to [-0.5,0.5] unlike when using the imaging subset where
 all intermediate values are required to stay within the range [0.0,1.0]
 */
 
+#ifdef GL_ES
+precision highp float;
+#endif
+
+// Fed by video_generic.vs. These replace gl_TexCoord[0..2], which is a
+// compatibility built-in and does not exist in OpenGL ES.
+// The NUON framebuffer goes to the GPU as raw bytes. Desktop uploads them with
+// GL_BGRA, so the driver reorders and the shader takes .bgr to get back to the
+// original byte order; OpenGL ES has no BGRA, uploads the same bytes as GL_RGBA
+// and therefore wants no reordering at all. Same pixels either way.
+#ifdef GL_ES
+#define NUON_TEXEL3(t) (t).rgb
+#define NUON_TEXEL4(t) (t).rgba
+#else
+#define NUON_TEXEL3(t) (t).bgr
+#define NUON_TEXEL4(t) (t).bgra
+#endif
+
+varying vec2 v_texcoord0;
+varying vec2 v_texcoord1;
+varying vec2 v_texcoord2;
+
 uniform sampler2D mainChannelSampler;
 uniform sampler2D overlayChannelSampler;
 uniform sampler2D LUTSampler;
@@ -81,7 +103,7 @@ vec3 texture2D_main(vec2 uv_org)
       uv = clamp(uv,vec2(0.,0.),vec2((720.0-1.0)*scaleInternal.x,(resy-1.)*scaleInternal.y));
       uv *= vec2(0.0013888889,1./resy); // 1./720
 
-      mainColor = texture2D(mainChannelSampler, uv).bgr; //!! throws away alpha, but should not matter as this is the final displayed buffer anyway!
+      mainColor = NUON_TEXEL3(texture2D(mainChannelSampler, uv)); //!! throws away alpha, but should not matter as this is the final displayed buffer anyway!
     }
 
     mainColor = clamp(mainColor*expansion-preBiasExpansion, 0.0, 1.0);
@@ -130,7 +152,7 @@ vec4 texture2D_overlay(vec2 uv_org)
       uv = clamp(uv,vec2(0.,0.),vec2((720.0-1.0)*scaleInternal.z,(resy-1.)*scaleInternal.w));
       uv *= vec2(0.0013888889,1./resy); // 1./720
 
-      overlayColor = texture2D(overlayChannelSampler, uv).bgra;
+      overlayColor = NUON_TEXEL4(texture2D(overlayChannelSampler, uv));
     }
 
     if(overlayColor.xyz == vec3(0.0,0.0,0.0)) // invalid overlay pixel -> fully transparent overlay pixel //!! should this also be interpolated??
@@ -175,7 +197,7 @@ float sqr(float x)
 
 void main()
 {
-  vec2 uvw   = vec2(gl_TexCoord[2].x,windowRes.y-gl_TexCoord[2].y); // window/screen coords in pixels (flipped y just to match reshade)
+  vec2 uvw   = vec2(v_texcoord2.x,windowRes.y-v_texcoord2.y); // window/screen coords in pixels (flipped y just to match reshade)
   vec2 uvw01 = uvw/windowRes;                                       // window/screen coords in 0..1,0..1
 
   // limit mask size
@@ -189,8 +211,8 @@ void main()
   if(windowRes.y > resy*2.)
     uvw.y *= resy*2./windowRes.y;
 
-  vec2 uvm = gl_TexCoord[0].xy; // main buffer
-  vec2 uvo = gl_TexCoord[1].xy; // overlay buffer
+  vec2 uvm = v_texcoord0; // main buffer
+  vec2 uvo = v_texcoord1; // overlay buffer
 
   vec3 col;
   vec2 offs = vec2( 0.001, 0.001);


### PR DESCRIPTION
The libretro core built for x64 Linux, x64 Windows and macOS. This adds the rest of what `.gitlab-ci.yml` can reach: `windows-i686`, both Android ABIs, `ios-arm64` and `tvos-arm64`.

Most of the work is not the CI entries — it is that the renderer could not have run on any of them.

## The renderer

`video.cpp` drew through display lists, `glBegin`/`glEnd`, `glMultiTexCoord`, `gl_TexCoord` and the fixed-function matrix stack. None of that exists in OpenGL ES; it is all compatibility-profile desktop GL. So the channel blit now goes through vertex attributes and `glDrawArrays`, with the ortho projection travelling to the vertex shader as `u_mvp` instead of living in a matrix stack, and the shaders were rewritten to attributes and varyings. `ShaderProgram` moved from the ARB extension API to the core GL 2.0 one, which ES has.

Desktop output is unchanged — that was checked against the previous build on Ballistic, four times over, because a port like this is exactly where a subtle difference hides.

`src/gl_headers.h` is the single place that decides which headers a target gets: GLEW on desktop, `GLES3/gl3.h` on Android, and Apple's own `OpenGLES/ES3/gl.h` on iOS and tvOS. ES 3 rather than ES 2 because the video buffers are declared with `GL_RGBA8`, `GL_RG8` and `GL_RG`, which ES 2 does not have.

## What each platform then needed

Everything below was found by building, one layer at a time — compile, then link, then symbols:

- **miniaudio** is dropped from the libretro build the way SDL2 already was. RetroArch owns the audio and no device is ever opened, so it was dead weight everywhere; on iOS it was worse, since miniaudio reaches for its Objective-C backends there and a C++ translation unit cannot compile them.
- **`-lpthread`** is not asked for on Android. Bionic has the pthread functions in libc and ships no such library, so requesting one is an error rather than the no-op it is elsewhere.
- **`archive.cpp`'s mount path** shells out to fuseiso, fuse-zip, archivemount and 7z. iOS and tvOS have neither `system()` nor `popen()`, and none of those tools to call if they did, so there it stands down rather than pretending. It was only ever a fallback — the in-process readers (miniz for zip, libchdr for chd, iso9660 for iso) cover every format it handled.
- **`std::filesystem`** is marked unavailable below iOS 13 and the deployment target is lower, so the cleanup uses `nftw` with `FTW_DEPTH`.
- **`-framework OpenGLES`** is two items to CMake, which reassembled them into `-framework -lOpenGLES`. `find_library` hands back a path, which survives being one item.
- **`__builtin___clear_cache`** lowers to a call into libgcc or compiler-rt, and the iOS link has neither, so every JIT cache flush in `nativecodecache` came out undefined. `sys_icache_invalidate` is Apple's own, and on Apple x86 a no-op the same way the builtin is. macOS did not show this — clang links compiler-rt itself there.
- **`GLES_SILENCE_DEPRECATION`**, because Apple deprecated OpenGL ES wholesale in iOS 12 in favour of Metal: without it every GL call warns, ninety-nine in one translation unit, which is enough to bury a warning worth reading.

## Verification, and its limit

`.github/workflows/verify-platforms.yml` compiles all eight targets on GitHub Actions before the buildbot sees them. All eight are green.

**That is a build, not a run.** Nobody has started the core on an Android device, an iPhone or an Apple TV; only the desktop output has been checked against a real game. Texture formats, precision qualifiers and missing extensions are the kind of thing a real ES driver rejects and a compiler does not, so the mobile targets should be treated as "builds and links" until someone runs one.

tvOS in particular had never been compiled by anything before this, despite `libretro-build-tvos-arm64` being in the recipe — it would have gone to the buildbot untried, so it gets a job here too.